### PR TITLE
Fix jQuery detection in WebRenderer

### DIFF
--- a/src/web/WebRenderer.C
+++ b/src/web/WebRenderer.C
@@ -832,9 +832,9 @@ void WebRenderer::serveMainscript(WebResponse& response)
   if (serveSkeletons) {
     bool haveJQuery = false;
     for (unsigned i = 0;
-	 i < app->scriptLibraries_.size() - app->scriptLibrariesAdded_;
+	 i < app->scriptLibraries_.size();
 	 ++i) {
-      if (app->scriptLibraries_[i].uri.find("jquery-") != std::string::npos) {
+      if (app->scriptLibraries_[i].uri.find("jquery") != std::string::npos) {
 	haveJQuery = true;
 	break;
       }


### PR DESCRIPTION
Allow jQuery detection to function properly, and remove the dash so that CDNs like Google, which do not include a dash in the filename, will be detected.

http://redmine.webtoolkit.eu/issues/1317
