### PR TITLE
Fix tab/menu select without javascript.

### DIFF
--- a/src/Wt/WMenuItem.C
+++ b/src/Wt/WMenuItem.C
@@ -241,7 +241,8 @@ void WMenuItem::updateInternalPath()
   } else {
     WAnchor *a = anchor();
     if (a) {
-      if (WApplication::instance()->environment().agent() == WEnvironment::IE6)
+      if ((WApplication::instance()->environment().agent() == WEnvironment::IE6) ||
+          !WApplication::instance()->environment().javaScript())
 	a->setLink(WLink("#"));
       else
 	a->setLink(WLink());


### PR DESCRIPTION
Fix issue where click on a WTabWidget tab without an explicit link
is ignored when client is not running javascript.

Needs review and additional testing.
