### PR TITLE
Address layout bug affecting firefox, bug #1821.

### DIFF
--- a/src/js/StdGridLayoutImpl2.js
+++ b/src/js/StdGridLayoutImpl2.js
@@ -109,10 +109,15 @@ WT_DECLARE_WT_MEMBER
      /* Allow accurate measurement for widgets with offsets */
      var l = element.style[DC.left];
      setCss(element, DC.left, NA_px);
+     var prev_size = element.style[DC.size];
+     setCss(element, DirConfig[dir].size, '');
      var scrollWidth = dir ? element.scrollHeight : element.scrollWidth;
      var clientWidth = dir ? element.clientHeight : element.clientWidth;
      var offsetWidth = dir ? element.offsetHeight : element.offsetWidth;
      setCss(element, DC.left, l);
+     if (prev_size) {
+       setCss(element, DirConfig[dir].size, prev_size);
+     }
 
 
      /*


### PR DESCRIPTION
Fix a layout issue that impacts at least some versions of firefox,
described in http://redmine.webtoolkit.eu/issues/1821.

It appears that the scrollHeight in Firefox is not being updated
as expected when there is no scroller and a height is set.
As a result, divs are not resized as expected.

This update removes the height constraint prior to measuring the
preferred height.  It may not be an optimal solution.

Note: this update addresses both height and width, although the
comments reflect a focus on height.  This code has not been extensively
tested, and should be reviewed and tested more completely to insure that
it does not break existing applications.
