### PR TITLE
Fix handling of zero length gzip-encoded replies.

### DIFF
--- a/src/http/Reply.C
+++ b/src/http/Reply.C
@@ -529,9 +529,14 @@ void Reply::encodeNextContentBuffer(
 	  }
 	} while (gzipStrm_.avail_out == 0);
       }
-    } else if (gzipStrm_.next_in) {
+    } else {
       unsigned char out[16*1024];
+      unsigned char in[1];
       do {
+	if (!gzipStrm_.next_in) {
+	  gzipStrm_.next_in = in;
+	  gzipStrm_.avail_in = 0;
+	}
 	gzipStrm_.next_out = out;
 	gzipStrm_.avail_out = sizeof(out);
 


### PR DESCRIPTION
Address issue in which gzip-encoded content of zero length is sent with
a length of zero, rather than a correct gzip-encoding.  See bug #1934.

Note: zero length content is currently generated in response to style
requests when nojs or noBootStyleResponse are true.
