### PR TITLE
Fixed WTextRenderer visibility

### DIFF
--- a/src/Wt/Render/WTextRenderer
+++ b/src/Wt/Render/WTextRenderer
@@ -72,7 +72,7 @@ struct LayoutBox;
  *
  * \ingroup render
  */
-class WTextRenderer 
+class WT_API WTextRenderer 
 {
 public:
   /*! \class Node


### PR DESCRIPTION
I ran into an issue when building the WidgetGallery example with VS 2012 using shared libraries. This patch resolves the issue by making base methods of WTextRenderer used by WPdfRenderer visible.
