### PR TITLE
WtFindMysql fixed to work with MySQL & MariaDB

### DIFF
--- a/cmake/WtFindMysql.txt
+++ b/cmake/WtFindMysql.txt
@@ -17,7 +17,7 @@ FIND_PATH(MYSQL_INCLUDE mysql.h
     /usr/local/include/mysql
 )
 
-SET(MYSQL_LIBRARY "mariadb;mariadbclient" CACHE STRING "Library that provides MySQL/MariaDB API (set to mysqlclient for mysql on unix; libmysql on windows)")
+SET(MYSQL_LIBRARY mysqlclient mariadb mariadbclient CACHE STRING "Library that provides MySQL/MariaDB API (set to mysqlclient for mysql on unix; libmysql on windows)")
 
 FIND_LIBRARY(MYSQL_LIB
     NAMES


### PR DESCRIPTION
In: wt/cmake/WtFindMysql.txt

Before: SET(MYSQL_LIBRARY "mariadb;mariadbclient" CACHE STRING "Library that provides MySQL/MariaDB API (set to mysqlclient for mysql on unix; libmysql on windows)")

Error in CMake:
*\* Wt::Dbo: not building MySQL backend.
    Indicate the location of your mariadb or mysqlclient installation using 
    -DMYSQL_PREFIX=... and the library to search for (e.g. mariadb or 
    mysqlclient) using -DMYSQL_LIBRARY=...

Afer: SET(MYSQL_LIBRARY mysqlclient mariadb mariadbclient CACHE STRING "Library that provides MySQL/MariaDB API (set to mysqlclient for mysql on unix; libmysql on windows)")

CMake OK:
*\* Wt::Dbo: building MySQL backend.
