### PR TITLE
Fix WtFindMysql.txt to support Fedora (mariadb / mysql)

### DIFF
--- a/cmake/WtFindMysql.txt
+++ b/cmake/WtFindMysql.txt
@@ -25,6 +25,8 @@ FIND_LIBRARY(MYSQL_LIB
     PATHS
     ${MYSQL_PREFIX}/lib
     ${MYSQL_PREFIX}/lib/opt
+    ${MYSQL_PREFIX}/lib/mysql
+    ${MYSQL_PREFIX}/lib64/mysql
     /usr/lib
     /usr/local/lib
     /opt/local/lib


### PR DESCRIPTION
Hi,

With Fedora distros, mysql / mariadb libraries are located under _/usr/lib/mysql_ for i686 and in _/usr/lib64/mysql_ for x86_64 arch.
