### PR TITLE
since vc2013 -> round(...) is declared in math.h

### DIFF
--- a/src/Wt/WTableView.C
+++ b/src/Wt/WTableView.C
@@ -28,7 +28,7 @@
 #include <cmath>
 #include <math.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 namespace {
   double round(double x)
   {

--- a/src/Wt/WTreeView.C
+++ b/src/Wt/WTreeView.C
@@ -29,7 +29,7 @@
 #include "js/WTreeView.min.js"
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 namespace {
   double round(double x)
   {


### PR DESCRIPTION
hi koen!

i just built latest git with vc2013 and got and error because of duplicate declaration of "round".
i think starting with vc2013 "round" is included in "math.h".

best regards and a happy new year!
max
