### PR TITLE
TIME_UTC problem workaround (boost 1.49, C++11)

### DIFF
--- a/examples/codeview/CodeSession.h
+++ b/examples/codeview/CodeSession.h
@@ -11,6 +11,7 @@
 #include <Wt/WSignal>
 
 #include <vector>
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 
 class CodeSession

--- a/examples/feature/broadcast/BroadCast.C
+++ b/examples/feature/broadcast/BroadCast.C
@@ -8,6 +8,7 @@
 #include <Wt/WMessageBox>
 #include <Wt/WServer>
 
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 
 /*

--- a/examples/feature/serverpush/ServerPush.C
+++ b/examples/feature/serverpush/ServerPush.C
@@ -9,6 +9,7 @@
 #include <Wt/WProgressBar>
 
 #include <iostream>
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 
 /*

--- a/examples/feature/socketnotifier/SocketNotifier.C
+++ b/examples/feature/socketnotifier/SocketNotifier.C
@@ -10,6 +10,7 @@
 #include <Wt/WText>
 
 #include <iostream>
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 
 #if WT_WIN32

--- a/examples/onethread/SingleThreadedApplication.h
+++ b/examples/onethread/SingleThreadedApplication.h
@@ -8,6 +8,7 @@
 #define SINGLE_THREADED_APPLICATION_H_
 
 #include <Wt/WApplication>
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 

--- a/examples/simplechat/SimpleChatServer.h
+++ b/examples/simplechat/SimpleChatServer.h
@@ -18,6 +18,7 @@ namespace Wt {
 
 #include <set>
 #include <map>
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 
 /**

--- a/examples/widgetgallery/Services.C
+++ b/examples/widgetgallery/Services.C
@@ -19,6 +19,7 @@
 #include "EmwebLoadingIndicator.h"
 
 #if defined(WT_THREADED) || defined(WT_TARGET_JAVA)
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #else
 #if WT_WIN32

--- a/examples/wtwithqt/lib/DispatchThread.h
+++ b/examples/wtwithqt/lib/DispatchThread.h
@@ -28,6 +28,7 @@
 
 #include <QThread>
 #ifndef Q_MOC_RUN // https://bugreports.qt.io/browse/QTBUG-22829
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 #endif

--- a/examples/wtwithqt/lib/WQApplication
+++ b/examples/wtwithqt/lib/WQApplication
@@ -27,6 +27,7 @@
 #define WQAPPLICATION_H_
 
 #include <Wt/WApplication>
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 
 /*! \file WQApplication */

--- a/examples/wtwithqt/lib/WQApplication.C
+++ b/examples/wtwithqt/lib/WQApplication.C
@@ -23,6 +23,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 #include <iostream>
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread/condition.hpp>
 
 #include "WQApplication"

--- a/src/Wt/Auth/OAuthService.C
+++ b/src/Wt/Auth/OAuthService.C
@@ -32,6 +32,7 @@
 #include "WebRequest.h"
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #endif // WT_THREADED
 

--- a/src/Wt/Dbo/FixedSqlConnectionPool.C
+++ b/src/Wt/Dbo/FixedSqlConnectionPool.C
@@ -8,6 +8,7 @@
 #include "Wt/Dbo/SqlConnection"
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 #else

--- a/src/Wt/FontSupportPango.C
+++ b/src/Wt/FontSupportPango.C
@@ -14,6 +14,7 @@
 #include "WebUtils.h"
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #endif // WT_THREADED
 

--- a/src/Wt/FontSupportSimple.C
+++ b/src/Wt/FontSupportSimple.C
@@ -13,6 +13,7 @@
 #include "FileUtils.h"
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #endif // WT_THREADED
 

--- a/src/Wt/Http/ResponseContinuation.C
+++ b/src/Wt/Http/ResponseContinuation.C
@@ -11,6 +11,7 @@
 #include "WebRequest.h"
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #endif
 

--- a/src/Wt/WBoostAny.C
+++ b/src/Wt/WBoostAny.C
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include "Wt/WConfig.h"
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #include <boost/shared_ptr.hpp>
 #endif // WT_THREADED

--- a/src/Wt/WIOService.C
+++ b/src/Wt/WIOService.C
@@ -11,6 +11,7 @@
 #include <boost/bind.hpp>
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #if !defined(WT_WIN32)
 #include <pthread.h>

--- a/src/Wt/WMemoryResource.C
+++ b/src/Wt/WMemoryResource.C
@@ -8,6 +8,7 @@
 #include "Wt/Http/Response"
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread/mutex.hpp>
 #endif // WT_THREADED
 

--- a/src/Wt/WMessageResources.C
+++ b/src/Wt/WMessageResources.C
@@ -27,6 +27,7 @@ using namespace Wt::rapidxml;
 
 #include <boost/version.hpp>
 
+#include "Wt/boost-xtime.hpp"
 #if BOOST_VERSION < 103600
 #include <boost/spirit.hpp>
 #include <boost/spirit/phoenix/binders.hpp>

--- a/src/Wt/WRandom.C
+++ b/src/Wt/WRandom.C
@@ -42,6 +42,7 @@
 #endif
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #endif
 

--- a/src/Wt/WResource
+++ b/src/Wt/WResource
@@ -15,6 +15,7 @@
 #include <iostream>
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread/condition.hpp>
 
 namespace boost {

--- a/src/Wt/WResource.C
+++ b/src/Wt/WResource.C
@@ -16,6 +16,7 @@
 #include "WebUtils.h"
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread/recursive_mutex.hpp>
 #endif // WT_THREADED
 

--- a/src/Wt/WSignal.C
+++ b/src/Wt/WSignal.C
@@ -4,6 +4,7 @@
  * See the LICENSE file for terms of use.
  */
 
+#include "Wt/boost-xtime.hpp"
 #include <boost/pool/pool.hpp>
 
 #include "Wt/WSignal"

--- a/src/Wt/boost-xtime.hpp
+++ b/src/Wt/boost-xtime.hpp
@@ -1,0 +1,82 @@
+// Copyright (C) 2001-2003
+// William E. Kempf
+// Copyright (C) 2007-8 Anthony Williams
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XTIME_WEK070601_HPP
+#define BOOST_XTIME_WEK070601_HPP
+
+#include <boost/thread/detail/config.hpp>
+
+#include <boost/cstdint.hpp>
+#include <boost/thread/thread_time.hpp>
+#include <boost/date_time/posix_time/conversion.hpp>
+
+#include <boost/config/abi_prefix.hpp>
+
+namespace boost {
+
+enum xtime_clock_types {
+    TIME_UTC_ = 1
+};
+
+struct xtime {
+#if defined(BOOST_NO_INT64_T)
+    typedef int_fast32_t xtime_sec_t; //INT_FAST32_MIN <= sec <= INT_FAST32_MAX
+#else
+    typedef int_fast64_t xtime_sec_t; //INT_FAST64_MIN <= sec <= INT_FAST64_MAX
+#endif
+
+    typedef int_fast32_t xtime_nsec_t;
+    //0 <= xtime.nsec < NANOSECONDS_PER_SECOND
+
+    xtime_sec_t sec;
+    xtime_nsec_t nsec;
+
+    operator system_time() const {
+        return boost::posix_time::from_time_t(0) +
+               boost::posix_time::seconds(static_cast<long>(sec)) +
+#ifdef BOOST_DATE_TIME_HAS_NANOSECONDS
+               boost::posix_time::nanoseconds(nsec);
+#else
+               boost::posix_time::microseconds((nsec + 500) / 1000);
+#endif
+    }
+
+};
+
+inline xtime get_xtime(boost::system_time const& abs_time) {
+    xtime res;
+    boost::posix_time::time_duration const time_since_epoch =
+        abs_time - boost::posix_time::from_time_t(0);
+    res.sec = static_cast<xtime::xtime_sec_t>(time_since_epoch.total_seconds());
+    res.nsec = static_cast<xtime::xtime_nsec_t>
+               (time_since_epoch.fractional_seconds() *
+                (1000000000 / time_since_epoch.ticks_per_second()));
+    return res;
+}
+
+inline int xtime_get(struct xtime* xtp, int clock_type) {
+    if (clock_type == TIME_UTC_) {
+        *xtp = get_xtime(get_system_time());
+        return clock_type;
+    }
+    return 0;
+}
+
+inline int xtime_cmp(const xtime& xt1, const xtime& xt2) {
+    if (xt1.sec == xt2.sec) {
+        return (int)(xt1.nsec - xt2.nsec);
+    } else {
+        return (xt1.sec > xt2.sec) ? 1 : -1;
+    }
+}
+
+} // namespace boost
+
+#include <boost/config/abi_suffix.hpp>
+
+#endif //BOOST_XTIME_WEK070601_HPP
+

--- a/src/fcgi/Server.h
+++ b/src/fcgi/Server.h
@@ -11,6 +11,7 @@
 #include <map>
 
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #endif // WT_THREADED
 

--- a/src/http/ConnectionManager.h
+++ b/src/http/ConnectionManager.h
@@ -21,6 +21,7 @@
 #include <boost/noncopyable.hpp>
 #include "Connection.h" // On WIN32, must be before thread stuff
 #ifdef WT_THREADED
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread/mutex.hpp>
 #endif // WT_THREADED
 

--- a/src/http/StaticReply.C
+++ b/src/http/StaticReply.C
@@ -5,6 +5,7 @@
  */
 
 #include <boost/lexical_cast.hpp>
+#include "Wt/boost-xtime.hpp"
 #include <boost/spirit/include/classic_core.hpp>
 
 #include "Configuration.h"

--- a/src/web/Configuration.h
+++ b/src/web/Configuration.h
@@ -17,6 +17,7 @@
 #endif
 
 #ifdef WT_CONF_LOCK
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #endif // WT_CONF_LOCK
 

--- a/src/web/WebController.h
+++ b/src/web/WebController.h
@@ -19,6 +19,7 @@
 #include "SocketNotifier.h"
 
 #if defined(WT_THREADED) && !defined(WT_TARGET_JAVA)
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #endif
 

--- a/src/web/WebRequest.C
+++ b/src/web/WebRequest.C
@@ -15,6 +15,7 @@
 
 #include <boost/version.hpp>
 
+#include "Wt/boost-xtime.hpp"
 #if BOOST_VERSION < 103600
 #include <boost/spirit.hpp>
 #else

--- a/src/web/WebSession.h
+++ b/src/web/WebSession.h
@@ -16,6 +16,7 @@
 #endif
 
 #ifdef WT_BOOST_THREADS
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 #endif

--- a/test/http/HttpClientServerTest.C
+++ b/test/http/HttpClientServerTest.C
@@ -8,6 +8,7 @@
 #ifdef WT_THREADED
 
 #include <boost/test/unit_test.hpp>
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 

--- a/test/http/HttpClientTest.C
+++ b/test/http/HttpClientTest.C
@@ -9,6 +9,7 @@
 #ifdef WT_THREADED
 
 #include <boost/test/unit_test.hpp>
+#include "Wt/boost-xtime.hpp"
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 

--- a/test/testenvironment/TestEnvironmentTest.C
+++ b/test/testenvironment/TestEnvironmentTest.C
@@ -7,6 +7,7 @@
 
 #ifdef WT_THREADED
 
+#include "Wt/boost-xtime.hpp"
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>


### PR DESCRIPTION
Definition of TIME_UTC in boost/thread/xtime.hpp conflicts with glibc definition of TIME_UTC (C++11). Both of them define TIME_UTC = 1. This problem was fixed in boost 1.50, but Wt declares needed boost version >= 1.41, so it should compile against versions < 1.50 with modern g++ with C++11 support.

Example of error message:

```
In file included from /usr/include/boost/thread/pthread/mutex.hpp:14:0,
                 from /usr/include/boost/thread/mutex.hpp:16,
                 from /usr/include/boost/spirit/home/classic/core/non_terminal/impl/object_with_id.ipp:17,
                 from /usr/include/boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp:15,
                 from /usr/include/boost/spirit/home/classic/core/non_terminal/grammar.hpp:21,
                 from /usr/include/boost/spirit/home/classic/core.hpp:42,
                 from /usr/include/boost/spirit/include/classic_core.hpp:11,
                 from /wt/src/http/StaticReply.C:8:
/usr/include/boost/thread/xtime.hpp:23:5: error: expected identifier before numeric constant
/usr/include/boost/thread/xtime.hpp:23:5: error: expected ‘}’ before numeric constant
```

gcc version 4.7.2

See https://bbs.archlinux.org/viewtopic.php?id=144593
