### PR TITLE
Added missing repaint() to WPolygonArea

### DIFF
--- a/src/Wt/WAbstractArea
+++ b/src/Wt/WAbstractArea
@@ -403,6 +403,9 @@ public:
    */
   EventSignal<WMouseEvent>& mouseWheel();
 
+  virtual void setAttributeValue(const std::string& name,
+				 const WT_USTRING& value);
+				 
 private:
   struct AnchorImpl {
     AnchorImpl(){}

--- a/src/Wt/WAbstractArea.C
+++ b/src/Wt/WAbstractArea.C
@@ -154,6 +154,12 @@ EventSignal<WMouseEvent>& WAbstractArea::mouseWheel()
   return impl_->mouseWheel();
 }
 
+void WAbstractArea::setAttributeValue(const std::string& name,
+			 const WT_USTRING& value)
+{
+    impl_->setAttributeValue(name, value);
+}
+
 void WAbstractArea::setImage(WImage *image)
 {
   impl_->setParent(image);

--- a/src/Wt/WInteractWidget.C
+++ b/src/Wt/WInteractWidget.C
@@ -466,9 +466,6 @@ void WInteractWidget::updateDom(DomElement& element, bool all)
 
     js << CheckDisabled;
 
-    if (mouseDrag)
-      js << "if (" WT_CLASS ".dragged()) return;";
-
     if (mouseDblClick && mouseDblClick->needsUpdate(all)) {
       /*
        * Click: if timer is running:
@@ -490,6 +487,9 @@ void WInteractWidget::updateDom(DomElement& element, bool all)
 	    js << ",0x1);";
 	}
       }
+      
+      if (mouseDrag)
+        js << "if (" WT_CLASS ".dragged()) return;";
 
       js << "if(" WT_CLASS ".isDblClick(o, e)) {"
 	 << mouseDblClick->javaScript();
@@ -524,8 +524,12 @@ void WInteractWidget::updateDom(DomElement& element, bool all)
       const Configuration& conf = app->environment().server()->configuration();
       js << "}," << conf.doubleClickTimeout() << ");}";
     } else {
+    
       if (mouseClick && mouseClick->needsUpdate(all)) {
 	js << mouseClick->javaScript();
+
+      if (mouseDrag)
+        js << "if (" WT_CLASS ".dragged()) return;";
 
 	if (mouseClick->isExposedSignal()) {
 	  js << app->javaScriptClass()

--- a/src/Wt/WPaintedWidget
+++ b/src/Wt/WPaintedWidget
@@ -245,6 +245,8 @@ public:
    * \sa objJsRef()
    */
   JSlot &repaintSlot() { return repaintSlot_; }
+  
+  WImage* areaImage() { return areaImage_; }
 
 protected:
   /*! \brief Create a WTransform that is accessible from JavaScript,

--- a/src/Wt/WPolygonArea.C
+++ b/src/Wt/WPolygonArea.C
@@ -67,6 +67,8 @@ void WPolygonArea::setPoints(const std::vector<WPoint>& points)
 void WPolygonArea::setPoints(const std::vector<WPointF>& points)
 {
   points_ = points;
+
+  repaint();
 }
 #endif // WT_TARGET_JAVA
 


### PR DESCRIPTION
Seems that the following issue: http://redmine.webtoolkit.eu/issues/2330 reoccures since commit https://github.com/kdeforche/wt/commit/fd45eb4b43112b0fa3a43049b8472d5043280b5b.
