### PR TITLE
Add option WT_FORCE_BOOST_DYN_LINK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ OPTION(ENABLE_LIBWTDBO "Build Wt::Dbo" ON)
 OPTION(WT_NO_STD_LOCALE "Build Wt to run on a system without std::locale support" OFF)
 OPTION(WT_NO_STD_WSTRING "Build Wt to run on a system without std::wstring support" OFF)
 OPTION(ENABLE_OPENGL "Build Wt with support for server-side opengl rendering" ON)
+OPTION(WT_FORCE_BOOST_DYN_LINK "Force BOOST_ALL_DYN_LINK when compiling Wt" OFF)
 
 # C++11 vs C++98
 # Binary compatibility is not guaranteed. We give our users the choice on
@@ -174,6 +175,11 @@ ENDIF(NOT SHARED_LIBS)
 IF(NOT MULTI_THREADED)
   OPTION(MULTI_THREADED "Build multi-threaded httpd deamon (if possible)" ON)
 ENDIF(NOT MULTI_THREADED)
+
+# Force dynamic linkage for all Boost libs if requested
+IF(WT_FORCE_BOOST_DYN_LINK)
+  ADD_DEFINITIONS(-DBOOST_ALL_DYN_LINK)
+ENDIF(WT_FORCE_BOOST_DYN_LINK)
 
 SET(BUILD_SHARED_LIBS ${SHARED_LIBS})
 


### PR DESCRIPTION
This commit adds a build option `WT_FORCE_BOOST_DYN_LINK` which enforces `-DBOOST_ALL_DYN_LINK`
being added to compiler flags. While it's technically possible to abuse variables like `WT_CPP_MODE` for this or set `CXXFLAGS` environment variables this is a slightly cleaner approach.

The reason for this is that with some combinations of Boost / Wt build options a program using both Wt and Boost.Log will crash when log sinks & related objects get destroyed since the're are conflicting symbols from static and dynamic variants of `libbost_log_setup` being mixed in the same binary.
