### PR TITLE
Added WCompositeWidget::formWidgetImpl() as an alternative to "WCompositeFormWidget":

### DIFF
--- a/src/Wt/WCompositeWidget
+++ b/src/Wt/WCompositeWidget
@@ -150,6 +150,9 @@ public:
   virtual void doJavaScript(const std::string& js);
   virtual void propagateSetEnabled(bool enabled);
 
+  static WFormWidget *getFormWidget(WWidget *widget);
+  WFormWidget* formWidgetImpl() { return fwImpl_; };
+
 #ifndef WT_TARGET_JAVA
   using WWidget::setFocus;
 #endif
@@ -171,6 +174,7 @@ protected:
    *       it has been rendered.
    */
   void setImplementation(WWidget *widget);
+  void setFormWidgetImpl(WFormWidget *formWidget);
  
   /*! \brief Get the implementation widget
    *
@@ -190,6 +194,8 @@ protected:
 
 private:
   WWidget *impl_;
+  WFormWidget *fwImpl_;
+  bool skipImplPropagateSetEnabled_;
 
   virtual void setLayout(WLayout *layout);
   virtual WLayout *layout();

--- a/src/Wt/WSuggestionPopup.C
+++ b/src/Wt/WSuggestionPopup.C
@@ -292,6 +292,9 @@ void WSuggestionPopup::modelLayoutChanged()
 
 void WSuggestionPopup::forEdit(WFormWidget *edit, WFlags<PopupTrigger> triggers)
 {
+  if(Utils::indexOf(edits_, edit) != -1)
+	return;
+
   EventSignalBase& b = edit->keyPressed();
 
   connectObjJS(b, "editKeyDown");

--- a/src/Wt/WTemplate
+++ b/src/Wt/WTemplate
@@ -169,6 +169,8 @@ private:
 	      std::ostream& result);
   bool _id(const std::vector<WString>& args, 
 	   std::ostream& result);
+  bool _fwId(const std::vector<WString>& args,
+	  std::ostream& result);
 
 public:
 #ifndef WT_TARGET_JAVA
@@ -327,6 +329,11 @@ public:
 #else
     static Function& id = IdFunction();
 #endif // WT_TARGET_JAVA
+
+	static bool fwId(WTemplate *t, const std::vector<WString>& args,
+		std::ostream& result);
+
+	//Please add Java Implementation
   };
 
   /*! \brief Enumeration that indicates how a widget's ID may be set.

--- a/src/Wt/WTemplate.C
+++ b/src/Wt/WTemplate.C
@@ -13,6 +13,8 @@
 #include "Wt/WContainerWidget"
 #include "Wt/WLogger"
 #include "Wt/WTemplate"
+#include "Wt/WCompositeWidget"
+#include "Wt/WFormWidget"
 
 #include "EscapeOStream.h"
 #include "WebUtils.h"
@@ -77,9 +79,31 @@ bool WTemplate::_id(const std::vector<WString>& args,
     } else
       return false;
   } else {
-    LOG_ERROR("Functions::tr(): expects exactly one argument");
+    LOG_ERROR("Functions::id(): expects exactly one argument");
     return false;
   }
+}
+
+bool WTemplate::_fwId(const std::vector<WString>& args,
+		    std::ostream& result)
+{
+	if(args.size() == 1) {
+		WWidget *w = this->resolveWidget(args[0].toUTF8());
+		if(w) {
+			WCompositeWidget *cw = dynamic_cast<WCompositeWidget *>(w);
+			if(cw && cw->formWidgetImpl())
+				result << cw->formWidgetImpl()->id();
+			else
+				result << w->id();
+			return true;
+		}
+		else
+			return false;
+	}
+	else {
+		LOG_ERROR("Functions::fwId(): expects exactly one argument");
+		return false;
+	}
 }
 
 #ifndef WT_TARGET_JAVA
@@ -105,6 +129,11 @@ bool WTemplate::Functions::id(WTemplate *t, const std::vector<WString>& args,
 			      std::ostream& result)
 {
   return t->_id(args, result);
+}
+
+bool WTemplate::Functions::fwId(WTemplate *t, const std::vector<WString>& args, std::ostream& result)
+{
+  return t->_fwId(args, result);
 }
 
 #else

--- a/src/Wt/WTemplateFormView.C
+++ b/src/Wt/WTemplateFormView.C
@@ -11,6 +11,7 @@
 #include "Wt/WText"
 #include "Wt/WTemplateFormView"
 #include "Wt/WTheme"
+#include "Wt/WCompositeWidget"
 
 #include "WebUtils.h"
 
@@ -143,14 +144,22 @@ void WTemplateFormView::updateViewField(WFormModel *model,
       bindWidget(var, edit);
     }
 
-    WFormWidget *fedit = dynamic_cast<WFormWidget *>(edit);
-    if (fedit) {
-      if (fedit->validator() != model->validator(field) &&
-	  model->validator(field))
-	fedit->setValidator(model->validator(field));
-      updateViewValue(model, field, fedit);
-    } else
-      updateViewValue(model, field, edit);
+	WFormWidget *fedit = dynamic_cast<WFormWidget *>(edit);
+    if(fedit)
+	{
+		if(fedit->validator() != model->validator(field) && model->validator(field))
+			fedit->setValidator(model->validator(field));
+
+		updateViewValue(model, field, fedit);
+    }
+	else
+	{
+		fedit = WCompositeWidget::getFormWidget(edit);
+		if(fedit && fedit->validator() != model->validator(field) && model->validator(field))
+			fedit->setValidator(model->validator(field));
+
+		updateViewValue(model, field, edit);
+	}
 
     WText *info = resolve<WText *>(var + "-info");
     if (!info) {


### PR DESCRIPTION
-Added feature to add WFormModel::validator to WCompositeWidget's WFormWidget Impl by WTemplateFormView
-Made the WCompositeWidget::setDisabled function similar to WWebWidget::setDisabled so that propagateSetEnabled should only be called when isEnabled() has changed
-Should have fixed WCompositeWidget::setDisabled so that it doesn't call impl_->propagateSetEnabled() twice, since impl_->setDisabled() should also call the same function
-Added WTemplate::Functions::fwId() to get WCompositeWidget::formWidgetImpl()'s ID or WObject::id()
-Added a test in WSuggestionPopup::forEdit so that multiple calls to forEdit shouldn't cause trouble
