### PR TITLE
WJavaScriptSlot: Pass slot's return value through to event caller

### DIFF
--- a/src/Wt/WJavaScriptSlot.C
+++ b/src/Wt/WJavaScriptSlot.C
@@ -101,7 +101,7 @@ void JSlot::setJavaScript(const std::string& js, int nbArgs)
     WApplication::instance()->declareJavaScriptFunction(jsFunctionName(), js);
   else {
     std::stringstream ss;
-    ss << "{var f=" << js << ";f(o,e";
+    ss << "{var f=" << js << ";return f(o,e";
     for (int i = 1; i <= nbArgs; ++i) {
       ss << ",a" << i;
     }


### PR DESCRIPTION
Being able to return values is at least useful to suppress key presses  by returning false in _onkeydown_. I have no idea about potential impact on other parts of Wt as I'm completely new to the library, but still this seems valid to me.
