### PR TITLE
Added support for Forward Secrecy to wthttpd

### DIFF
--- a/src/http/Configuration.C
+++ b/src/http/Configuration.C
@@ -57,6 +57,7 @@ Configuration::Configuration(Wt::WLogger& logger, bool silent)
     sslVerifyDepth_(1),
     sslCaCertificates_(),
     sslCipherList_(),
+    sslPreferServerCiphers_(false),
     sessionIdPrefix_(),
     accessLog_(),
     parentPort_(-1),
@@ -197,6 +198,12 @@ void Configuration::createOptions(po::options_description& options,
      "layer, so see openssl for the proper syntax. When empty, the default "
      "acceptable cipher list will be used. Example cipher list string: "
      "\"TLSv1+HIGH:!SSLv2\"\n")
+    ("ssl-prefer-server-ciphers",
+     po::value<bool>(&sslPreferServerCiphers_)
+       ->default_value(sslPreferServerCiphers_),
+     "By default, the client's preference is used for determining the cipher "
+     "that is choosen during a SSL or TLS handshake. By enabling this option, "
+     "the server's preference will be used." )
     ;
 
   po::options_description hidden("Hidden options");

--- a/src/http/Configuration.h
+++ b/src/http/Configuration.h
@@ -73,6 +73,7 @@ public:
   int sslVerifyDepth() const { return sslVerifyDepth_; }
   const std::string& sslCaCertificates() const { return sslCaCertificates_; }
   const std::string& sslCipherList() const { return sslCipherList_; }
+  const bool sslPreferServerCiphers() const { return sslPreferServerCiphers_; }
 
   const std::string& sessionIdPrefix() const { return sessionIdPrefix_; }
   const std::string& accessLog() const { return accessLog_; }
@@ -124,6 +125,7 @@ private:
   int sslVerifyDepth_;
   std::string sslCaCertificates_;
   std::string sslCipherList_;
+  bool sslPreferServerCiphers_;
 
   std::string sessionIdPrefix_;
   std::string accessLog_;

--- a/src/http/Server.C
+++ b/src/http/Server.C
@@ -212,12 +212,19 @@ void Server::start()
     ssl_context_.use_tmp_dh_file(config_.sslTmpDHFile());
     
     SSL_CTX *native_ctx = nativeContext(ssl_context_);
+
+#if defined(SSL_CTX_set_ecdh_auto)
+    SSL_CTX_set_ecdh_auto(native_ctx, 1);
+# endif
     
-    if (config_.sslCipherList().size()) {
+    if (!config_.sslCipherList().empty()) {
       if (!SSL_CTX_set_cipher_list(native_ctx, config_.sslCipherList().c_str())) {
         throw Wt::WServer::Exception(
           "failed to select ciphers for cipher list "
           + config_.sslCipherList());
+      }
+      if (config_.sslPreferServerCiphers()) {
+        SSL_CTX_set_options(native_ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
       }
     }
 


### PR DESCRIPTION
I've added support for forward secrecy to wthttpd. An option to set server cipher order preference is added. In addition, SSL_CTX_set_ecdh_auto, if available, is set to 1. Web servers such as Apache and nginx also set this to 1 by default.
