### PR TITLE
Update WMessageResources.C

### DIFF
--- a/src/Wt/WMessageResources.C
+++ b/src/Wt/WMessageResources.C
@@ -633,7 +633,7 @@ bool WMessageResources::readResourceStream(std::istream &s,
 
 int WMessageResources::evalPluralCase(const std::string &expression, ::uint64_t n)
 {
-  int result;
+  int result = 0;
 
 #ifndef WT_NO_SPIRIT
   CExpressionParser::ParseState state;


### PR DESCRIPTION
It's always good to initialize integer variables, at least to 0, because if you try to retrieve its value before it gets assigned any actual (non-garbage) value, then it results in undefined behavior, e.g. when the token WT_NO_SPIRIT is defined.

Found by https://github.com/bryongloden/cppcheck
