### PR TITLE
we must include API key as parameter in Google Maps API URI

### DIFF
--- a/src/Wt/WGoogleMap.C
+++ b/src/Wt/WGoogleMap.C
@@ -247,7 +247,7 @@ void WGoogleMap::render(WFlags<RenderFlag> flags)
 
     strm << "setTimeout(function(){ delete " << initFunction << ";}, 0)};"
 	 << "google.load(\"maps\", \"" << (apiVersion_ == Version2 ? '2' : '3')
-	 << "\", {other_params:\"sensor=false\", callback: "
+	 << "\", {other_params:\"key=" << googlekey << "\", callback: "
 	 << initFunction << "});"
 	 << "}"; // private scope
 


### PR DESCRIPTION
A couple of things here. sensor=false is deprecated, I removed it to eliminate warning messages with the Version 3 API. 
As of June 2016, Google requires all maps API requests to be authenticated. 
The jsapi auth and google.load method we've been using previously results in a MissingKeyMapError. 
It appears we must include API key as the 'key' parameter when constructing the URI for the maps script tag. After doing so it loads fine with no error or warning messages.
