### PR TITLE
overriding a member function but is not marked 'override'

### DIFF
--- a/src/Wt/WContainerWidget
+++ b/src/Wt/WContainerWidget
@@ -154,7 +154,7 @@ public:
    *
    * \sa layout()
    */
-  void setLayout(WLayout *layout);  
+  void setLayout(WLayout *layout) WT_CXX11ONLY(override);
 
   /*! \brief Sets a layout manager for the container (<b>deprecated</b>).
    *
@@ -197,7 +197,7 @@ public:
    *
    * \sa setLayout(WLayout *)
    */
-  WLayout *layout() { return layout_; }
+  virtual WLayout *layout() WT_CXX11ONLY(override) { return layout_; }
 
   /*! \brief Adds a child widget to this container.
    *
@@ -402,23 +402,23 @@ private:
 protected:
   using WWidget::removeChild;
 
-  virtual void removeChild(WWidget *child);
+  virtual void removeChild(WWidget *child) WT_CXX11ONLY(override);
   virtual int firstChildIndex() const;
 
-  virtual void childResized(WWidget *child, WFlags<Orientation> directions);
-  virtual void parentResized(WWidget *parent, WFlags<Orientation> directions);
+  virtual void childResized(WWidget *child, WFlags<Orientation> directions) WT_CXX11ONLY(override);
+  virtual void parentResized(WWidget *parent, WFlags<Orientation> directions) WT_CXX11ONLY(override);
   virtual void getDomChanges(std::vector<DomElement *>& result,
-			     WApplication *app);
+			     WApplication *app) WT_CXX11ONLY(override);
   DomElement *createDomElement(WApplication *app, bool addChildren);
   void createDomChildren(DomElement& parent, WApplication *app);
   void updateDomChildren(DomElement& parent, WApplication *app);
 
-  virtual DomElementType domElementType() const;
-  virtual void           updateDom(DomElement& element, bool all);
-  virtual void propagateRenderOk(bool deep);
-  virtual DomElement    *createDomElement(WApplication *app);
+  virtual DomElementType domElementType() const WT_CXX11ONLY(override);
+  virtual void           updateDom(DomElement& element, bool all) WT_CXX11ONLY(override);
+  virtual void propagateRenderOk(bool deep) WT_CXX11ONLY(override);
+  virtual DomElement    *createDomElement(WApplication *app) WT_CXX11ONLY(override);
 
-  virtual WLayoutItemImpl *createLayoutItemImpl(WLayoutItem *item);
+  virtual WLayoutItemImpl *createLayoutItemImpl(WLayoutItem *item) WT_CXX11ONLY(override);
   StdLayoutImpl *layoutImpl() const;
   virtual void setFormData(const FormData& formData) WT_CXX11ONLY(override);
 

--- a/src/Wt/WInteractWidget
+++ b/src/Wt/WInteractWidget
@@ -340,14 +340,14 @@ public:
    */
   int mouseOverDelay() const;
 
-  virtual void setPopup(bool popup);
-  virtual void load();
-  virtual bool isEnabled() const;
+  virtual void setPopup(bool popup) WT_CXX11ONLY(override);
+  virtual void load() WT_CXX11ONLY(override);
+  virtual bool isEnabled() const WT_CXX11ONLY(override);
 
 protected:
-  virtual void updateDom(DomElement& element, bool all);
-  virtual void propagateRenderOk(bool deep);
-  virtual void propagateSetEnabled(bool enabled);
+  virtual void updateDom(DomElement& element, bool all) WT_CXX11ONLY(override);
+  virtual void propagateRenderOk(bool deep) WT_CXX11ONLY(override);
+  virtual void propagateSetEnabled(bool enabled) WT_CXX11ONLY(override);
 
   void updateEventSignals(DomElement& element, bool all);
 


### PR DESCRIPTION
Compiling with C++11 enabled, triggers warnings through the whole build process.
e.g
warning: '***' overrides a member function but is not marked 'override'

CMake conf:
cmake -DCMAKE_BUILD_TYPE=Release -DBOOST_DIR=$SRC_INSTALL
-DMULTI_THREADED=ON -DSHARED_LIBS=OFF
-DCMAKE_CXX_FLAGS_RELEASE="-std=c++11" -DCMAKE_INSTALL_PREFIX=$iname
-DWTHTTP_CONFIGURATION=$iname/etc -DRUNDIR=$iname/run
-DCONFIGURATION=$iname/etc -DDEPLOYROOT=$iname/examples
-DCONFIGDIR=$iname/etc -DCONNECTOR_HTTP=ON -DBUILD_EXAMPLES=OFF
-DBUILD_TESTS=OFF -DCONNECTOR_FCGI=OFF -DWEBUSER=www -DWEBGROUP=www
~/src/wt/

Platform:
Apple LLVM version 7.3.0 (clang-703.0.31)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoo
lchain/usr/bin

Compiler warnings reported:
[-Winconsistent-missing-override]

cheers
denn
