### PR TITLE
Add AlwaysShowEditors EditOption

### DIFF
--- a/src/Wt/WAbstractItemView
+++ b/src/Wt/WAbstractItemView
@@ -57,10 +57,11 @@ public:
    * \sa setEditOptions()
    */
   enum EditOption {
-    SingleEditor = 0x1,    //!< Never show more than one active editor
-    MultipleEditors = 0x2, //!< Allow multiple editors at the same time
-    SaveWhenClosed = 0x4,  //!< Always save the current edit value when closing
-    LeaveEditorsOpen = 0x8 //!< Editors can only be closed using closeEditor()
+    SingleEditor = 0x1,      //!< Never show more than one active editor
+    MultipleEditors = 0x2,   //!< Allow multiple editors at the same time
+    SaveWhenClosed = 0x4,    //!< Always save the current edit value when closing
+    LeaveEditorsOpen = 0x8,  //!< Editors can only be closed using closeEditor()
+    AlwaysShowEditors = 0x10 //!< Editors are always displayed and can't be closed()
   };
 
   /*! \brief Enumeration that specifies a scrolling option.

--- a/src/Wt/WAbstractItemView.C
+++ b/src/Wt/WAbstractItemView.C
@@ -1394,7 +1394,7 @@ void WAbstractItemView::closeEditorWidget(WWidget *editor, bool saveData)
   for (EditorMap::iterator i = editedItems_.begin();
        i != editedItems_.end(); ++i)
     if (i->second.widget == editor) {
-      if (editOptions_ & LeaveEditorsOpen) {
+      if (editOptions_ & (LeaveEditorsOpen | AlwaysShowEditors)) {
 	// Save data, but keep editor open
 	if (saveData)
 	  saveEditedValue(i->first, i->second);

--- a/src/Wt/WTableView.C
+++ b/src/Wt/WTableView.C
@@ -280,6 +280,10 @@ WWidget* WTableView::renderWidget(WWidget* widget, const WModelIndex& index)
       renderFlags |= RenderSelected;
   }
 
+  if (editOptions() & AlwaysShowEditors) {
+    edit(index);
+  }
+
   if (isEditing(index)) {
     renderFlags |= RenderEditing;
     if (hasEditFocus(index))


### PR DESCRIPTION
This causes a WTableView to render the editor for any editable indexes.
It also adds the editor to the internal editedItems_ container which enables editing of the model.

This pull request is about the following comment in this thread:
[http://redmine.webtoolkit.eu/boards/2/topics/9148](http://redmine.webtoolkit.eu/boards/2/topics/9148)

> If you always want to show the combobox, specialize WAbstractItemDelegate, and implement update() so that it always renders a combobox.

I am unable to get a custom delegate based directly on WAbstractItemDelegate to call setModelData().
After looking at the code I think this is because WAbstractItemView::closeEditorWidget()
does not find the editor in its editedItems_ container. This is because editing has not been triggered.
This request therefore triggers editing automatically by calling the edit() function.

Have I missed something??
