### PR TITLE
Fix WTimePicker segfault on construction

### DIFF
--- a/src/Wt/WTimePicker.C
+++ b/src/Wt/WTimePicker.C
@@ -18,6 +18,7 @@ LOGGER("WTimePicker");
 WTimePicker::WTimePicker(WContainerWidget *parent)
     : WCompositeWidget(parent),
       selectionChanged_(this),
+      timeEdit_(new WTimeEdit()),
       toggleAmPm_(2, this)
 {
     init();
@@ -25,6 +26,7 @@ WTimePicker::WTimePicker(WContainerWidget *parent)
 
 WTimePicker::WTimePicker(const WTime &time, WContainerWidget *parent)
     : WCompositeWidget(parent),
+      timeEdit_(new WTimeEdit()),
       toggleAmPm_(2, this)
 {
     init(time);


### PR DESCRIPTION
Constructors which do not take a WTimeEdit as parameter segfault
due to dereferencing uninitialised timeEdit_ variable.
Issue fixed by default initialising timeEdit_ in these cases