### PR TITLE
MySQL DBO. Changed deprecated variable.

### DIFF
--- a/src/Wt/Dbo/backend/MySQL.C
+++ b/src/Wt/Dbo/backend/MySQL.C
@@ -968,7 +968,7 @@ bool MySQL::connect(const std::string &db,  const std::string &dbuser,
 void MySQL::init()
 {
   executeSql("SET sql_mode='ANSI_QUOTES,REAL_AS_FLOAT'");
-  executeSql("SET storage_engine=INNODB;");
+  executeSql("SET default_storage_engine=INNODB;");
   executeSql("SET NAMES 'utf8';");
 }
 


### PR DESCRIPTION
Changed storage_engine to default_storage_engine as first one
is [removed](http://mysqlserverteam.com/removal-and-deprecation-in-mysql-5-7/) in MySQL version 5.7.

Signed-off-by: Alexey Slaykovsky <alexey@slaykovsky.com>