### PR TITLE
HTTP PATCH support for Wt 3.7

### DIFF
--- a/src/Wt/Http/Client
+++ b/src/Wt/Http/Client
@@ -285,7 +285,22 @@ public:
    * \sa request(), done()
    */
   bool deleteRequest(const std::string& url, const Message& message);
-  
+
+  /*! \brief Starts a PATCH request.
+   *
+   * The function starts an asynchronous PATCH request, and returns
+   * immediately.
+   *
+   * The function returns \c true when the PATCH request has been
+   * scheduled, and thus done() will be emitted eventually.
+   *
+   * The function returns \p false if the client could not schedule
+   * the request, for example if the \p url is invalid or if the %URL
+   * scheme is not supported.
+   *
+   * \sa request(), done()
+   */
+  bool patch(const std::string& url, const Message& message);
   /*! \brief Starts a request.
    *
    * The function starts an asynchronous HTTP request, and returns

--- a/src/Wt/Http/Client.C
+++ b/src/Wt/Http/Client.C
@@ -994,7 +994,7 @@ void Client::handleRedirect(Http::Method method, boost::system::error_code err, 
     const std::string *newUrl = response.getHeader("Location");
     ++ redirectCount_;
     if (newUrl && redirectCount_ <= maxRedirects_) {
-       request(method, *newUrl, request);
+       this->request(method, *newUrl, request);
        return;
     }
     if(!newUrl) {

--- a/src/Wt/Http/Client.C
+++ b/src/Wt/Http/Client.C
@@ -74,8 +74,8 @@ public:
 
   virtual ~Impl() { }
 
-  void setTimeout(int timeout) { 
-    timeout_ = timeout; 
+  void setTimeout(int timeout) {
+    timeout_ = timeout;
   }
 
   void setMaximumResponseSize(std::size_t bytes) {
@@ -95,7 +95,7 @@ public:
                      << boost::lexical_cast<std::string>(port) << "\r\n";
 
     if (!auth.empty())
-      request_stream << "Authorization: Basic " 
+      request_stream << "Authorization: Basic "
 		     << Wt::Utils::base64Encode(auth) << "\r\n";
 
     bool haveContentLength = false;
@@ -108,12 +108,12 @@ public:
 
     if ((method == "POST" || method == "PUT" || method == "DELETE") &&
 	!haveContentLength)
-      request_stream << "Content-Length: " << message.body().length() 
+      request_stream << "Content-Length: " << message.body().length()
 		     << "\r\n";
 
     request_stream << "Connection: close\r\n\r\n";
 
-    if (method == "POST" || method == "PUT" || method == "DELETE")
+    if(method == "POST" || method == "PUT" || method == "DELETE" || method == "PATCH")
       request_stream << message.body();
 
     tcp::resolver::query query(server, boost::lexical_cast<std::string>(port));
@@ -227,7 +227,7 @@ private:
       complete();
     }
   }
- 
+
   void handleConnect(const boost::system::error_code& err,
 		     tcp::resolver::iterator endpoint_iterator)
   {
@@ -387,7 +387,7 @@ private:
 	  }
 	}
       }
-      
+
       if (headersReceived_.isConnected()) {
 	if (server_)
 	  server_->post(sessionId_,
@@ -496,7 +496,7 @@ private:
 	  }
 
 	  chunkState_.parsePos = 0;
-	  
+
 	  break;
 	case 0:
 	  if (ch >= '0' && ch <= '9') {
@@ -531,7 +531,7 @@ private:
 	  if (chunkState_.size == 0) {
 	    chunkState_.state = ChunkState::Complete; return;
 	  }
-	    
+
 	  chunkState_.state = ChunkState::Data;
 	}
 
@@ -566,7 +566,7 @@ private:
     err_ = boost::system::errc::make_error_code
       (boost::system::errc::protocol_error);
     complete();
-  } 
+  }
 
   void complete()
   {
@@ -823,7 +823,7 @@ bool Client::get(const std::string& url)
   return request(Get, url, Message());
 }
 
-bool Client::get(const std::string& url, 
+bool Client::get(const std::string& url,
 		 const std::vector<Message::Header> headers)
 {
   Message m(headers);
@@ -838,6 +838,11 @@ bool Client::post(const std::string& url, const Message& message)
 bool Client::put(const std::string& url, const Message& message)
 {
   return request(Put, url, message);
+}
+
+bool Client::patch(const std::string& url, const Message& message)
+{
+  return request(Patch, url, message);
 }
 
 bool Client::deleteRequest(const std::string& url, const Message& message)
@@ -906,9 +911,9 @@ bool Client::request(Http::Method method, const std::string& url,
 #endif // VERIFY_CERTIFICATE
 
     impl_.reset(new SslImpl(*ioService, verifyEnabled_,
-			    server, 
-			    context, 
-			    sessionId, 
+			    server,
+			    context,
+			    sessionId,
 			    parsedUrl.host));
 #endif // WT_WITH_SSL
 
@@ -933,16 +938,16 @@ bool Client::request(Http::Method method, const std::string& url,
   impl_->setTimeout(timeout_);
   impl_->setMaximumResponseSize(maximumResponseSize_);
 
-  const char *methodNames_[] = { "GET", "POST", "PUT", "DELETE" };
+  const char *methodNames_[] = { "GET", "POST", "PUT", "DELETE", "PATCH" };
 
   LOG_DEBUG(methodNames_[method] << " " << url);
 
-  impl_->request(methodNames_[method], 
+  impl_->request(methodNames_[method],
 		 parsedUrl.protocol,
 		 parsedUrl.auth,
-		 parsedUrl.host, 
-		 parsedUrl.port, 
-		 parsedUrl.path, 
+		 parsedUrl.host,
+		 parsedUrl.port,
+		 parsedUrl.path,
 		 message);
 
   return true;

--- a/src/Wt/Http/Method
+++ b/src/Wt/Http/Method
@@ -16,10 +16,11 @@ namespace Wt {
  * used HTTP methods.
  */
 enum Method {
-  Get,   //!< a HTTP GET
-  Post,  //!< a HTTP POST
-  Put,   //!< a HTTP PUT
-  Delete //!< a HTTP DELETE
+  Get,    //!< a HTTP GET
+  Post,   //!< a HTTP POST
+  Put,    //!< a HTTP PUT
+  Delete, //!< a HTTP DELETE
+  Patch   //!< a HTTP PATCH
 };
 
   }

--- a/src/http/RequestHandler.C
+++ b/src/http/RequestHandler.C
@@ -99,6 +99,7 @@ ReplyPtr RequestHandler::handleRequest(Request& req,
       && (req.method != "OPTIONS")
       && (req.method != "POST")
       && (req.method != "PUT")
+      && (req.method != "PATCH")
       && (req.method != "DELETE"))
     return ReplyPtr(new StockReply(req, Reply::not_implemented, "", config_));
 


### PR DESCRIPTION
This patchset adds support for making Http Patch requests using Wt::Http::Client.
This patchset allows WResource to respond to Http Patch requests.
This patchset expands Wt::Http::Redirection support to allow for Method preserving redirection - e.g. Http 307/308 with a POST results in a Post.
This patchset expands Wt::Http::Redirection support to allow for Method translating redirection - e.g. Http 301/302 with a POST results in a Get.


