### PR TITLE
Patch: fixes pass vector by const ref, not const copy

### DIFF
--- a/src/Wt/Http/Client
+++ b/src/Wt/Http/Client
@@ -236,7 +236,7 @@ public:
    *
    * \sa request(), done()
    */
-  bool get(const std::string& url, const std::vector<Message::Header> headers);
+  bool get(const std::string& url, const std::vector<Message::Header> & headers);
 
   /*! \brief Starts a POST request.
    *

--- a/src/Wt/Http/Client.C
+++ b/src/Wt/Http/Client.C
@@ -823,8 +823,8 @@ bool Client::get(const std::string& url)
   return request(Get, url, Message());
 }
 
-bool Client::get(const std::string& url, 
-		 const std::vector<Message::Header> headers)
+bool Client::get(const std::string& url,
+		 const std::vector<Message::Header> & headers)
 {
   Message m(headers);
   return request(Get, url, m);


### PR DESCRIPTION
Fixed argument to in Http::Client::get().
It looks like this was intended to accept an argument by const ref, but via typo took a const copy.