### PR TITLE
Workaround issue when compiling with Boost 1.64

### DIFF
--- a/src/Wt/WGenericMatrix
+++ b/src/Wt/WGenericMatrix
@@ -15,6 +15,7 @@
 #pragma warning( disable : 4267 )
 #endif
 #define BOOST_SERIALIZATION_NO_LIB
+#include <boost/serialization/array_wrapper.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
 #ifdef _MSC_VER
 #pragma warning( pop )


### PR DESCRIPTION
Workaround issue when compiling with Boost 1.64. See here: http://redmine.webtoolkit.eu/boards/2/topics/13412