### PR TITLE
Cursor image url needs to be cleared for "normal" cursor usage

### DIFF
--- a/src/Wt/WCssDecorationStyle.C
+++ b/src/Wt/WCssDecorationStyle.C
@@ -112,8 +112,10 @@ void WCssDecorationStyle::changed(WFlags<RepaintFlag> flags)
 void WCssDecorationStyle::setCursor(Cursor c)
 {
   if (!WWebWidget::canOptimizeUpdates()
+	  || !cursorImage_.empty()
       || cursor_ != c) {
-    cursor_ = c;
+	cursorImage_.clear();
+	cursor_ = c;
     cursorChanged_ = true;
     changed();
   }


### PR DESCRIPTION
There was a little problem if first a custom cursor with an image url was used and after that a standard cursor (with Cursor enum), same as fallback cursor,  was used. Then the new curser was never displayed