### PR TITLE
Make WSortFilterProxyModel handle src-model-reset

### DIFF
--- a/src/Wt/WSortFilterProxyModel.C
+++ b/src/Wt/WSortFilterProxyModel.C
@@ -124,6 +124,9 @@ void WSortFilterProxyModel::setSourceModel(WAbstractItemModel *model)
   modelConnections_.push_back(sourceModel()->layoutChanged().connect
      (this, &WSortFilterProxyModel::sourceLayoutChanged));
 
+  modelConnections_.push_back(sourceModel()->modelReset().connect
+     (this, &WSortFilterProxyModel::reset));
+
   resetMappings();
 }
 


### PR DESCRIPTION
The filter-proxy-model now emits its modelReset signal when its
source model does so

http://redmine.webtoolkit.eu/boards/1/topics/12567

Is this behaviour correct?

I am currently unable to reproduce the issue which required a call
to invalidate() or resetMappings(), perhaps this should be checked
if you decide to merge