### PR TITLE
Compile-fix for when CSS_PARSER is not defined

### DIFF
--- a/src/Wt/Render/CssParser.C
+++ b/src/Wt/Render/CssParser.C
@@ -501,22 +501,22 @@ namespace Wt {
 CssParser::CssParser()
 { }
 
-StyleSheet* CssParser::parse(const WString& styleSheetContents)
+std::unique_ptr<StyleSheet> CssParser::parse(const WString& styleSheetContents)
 {
   error_.clear();
 
   if (styleSheetContents.empty())
-    return new StyleSheetImpl();
+    return cpp14::make_unique<StyleSheetImpl>();
   else {
     error_ = "Wt::Render: CSSParser requires Boost 1.47 or later";
-    return 0;
+    return nullptr;
   }
 }
 
-StyleSheet* CssParser::parseFile(const WString& filename)
+std::unique_ptr<StyleSheet> CssParser::parseFile(const WString& filename)
 {
   error_ = "Wt::Render: CSSParser requires Boost 1.47 or later";
-  return 0;
+  return nullptr;
 }
 
 std::string CssParser::getLastError() const


### PR DESCRIPTION
One of my machines (2GB RAM, no swap) runs out of memory compiling CssParser.C. For Wt3 I could undefine CSS_PARSER in that file and compile a working library. For Wt4, I get a compile error (seems like someone forgot to upgrade this part of the code). Provided is a compile-fix.