### PR TITLE
Fix issue #6261

### DIFF
--- a/src/Wt/WTreeView.C
+++ b/src/Wt/WTreeView.C
@@ -2850,6 +2850,7 @@ WAbstractItemView::ColumnInfo WTreeView::createColumnInfo(int column) const
 
     if (c0StyleRule_) {
       c0StyleRule_->setSelector("#" + id() + " li ." + ci.styleClass());
+      wApp->styleSheet().removeRule(c0StyleRule_);
       wApp->styleSheet().addRule(c0StyleRule_); // needed on rerender
     }
   }


### PR DESCRIPTION
Pull Request fixing redmine issue #6261
https://redmine.webtoolkit.eu/issues/6261

`c0StyleRule_` got readded on every model change. 
In `~WCssRule` only the first occurence in `rules_` got erased.
In `~WApplication -> styleSheet_.clear(); -> ~WCssStyleSheet` -> crash because of deleting already deleted entry of rules_

There are severeal possibilities of fixing this, the one provided was the quickest for me.

Best regards,
Max