### PR TITLE
Corrected documentation about ownership transfer

### DIFF
--- a/src/Wt/WAbstractItemView.h
+++ b/src/Wt/WAbstractItemView.h
@@ -82,12 +82,6 @@ public:
    *
    * The initial model is \c 0.
    *
-   * \if cpp
-   * Ownership of the model is not transferred (and thus the
-   * previously set model is not deleted). A model may not be deleted as
-   * long as a view exists for it.
-   * \endif
-   *
    * \sa setRootIndex()
    */
   virtual void setModel(const std::shared_ptr<WAbstractItemModel>& model);


### PR DESCRIPTION
With Wt 4, ownership is made explicit, so no comment need be made
about how ownership works, or under what circumstances a model
will be deleted.