### PR TITLE
Correcting typo and remove example comments

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@ Running the examples
 
 The examples that come with the library will by default be linked
 against the built-in httpd. In any case, we recommend this way of
-exploring the examples and trying them out, even you'll end up
+exploring the examples and trying them out, even if you'll end up
 deploying using FastCGI or ISAPI.
 
 You typically need the following commands to run an example (`foobar`):

--- a/examples/feature/auth2/AuthWidget.h
+++ b/examples/feature/auth2/AuthWidget.h
@@ -1,4 +1,3 @@
-// This may look like C code, but it's really -*- C++ -*-
 /*
  * Copyright (C) 2011 Emweb bvba, Kessel-Lo, Belgium.
  *

--- a/examples/feature/auth2/RegistrationView.h
+++ b/examples/feature/auth2/RegistrationView.h
@@ -1,4 +1,3 @@
-// This may look like C code, but it's really -*- C++ -*-
 /*
  * Copyright (C) 2012 Emweb bvba, Kessel-Lo, Belgium.
  *

--- a/examples/feature/auth2/model/Session.h
+++ b/examples/feature/auth2/model/Session.h
@@ -1,4 +1,3 @@
-// This may look like C code, but it's really -*- C++ -*-
 /*
  * Copyright (C) 2009 Emweb bvba, Kessel-Lo, Belgium.
  *

--- a/examples/feature/auth2/model/User.h
+++ b/examples/feature/auth2/model/User.h
@@ -1,4 +1,3 @@
-// This may look like C code, but it's really -*- C++ -*-
 /*
  * Copyright (C) 2009 Emweb bvba, Kessel-Lo, Belgium.
  *

--- a/examples/feature/auth2/model/UserDetailsModel.h
+++ b/examples/feature/auth2/model/UserDetailsModel.h
@@ -1,4 +1,3 @@
-// This may look like C code, but it's really -*- C++ -*-
 /*
  * Copyright (C) 2012 Emweb bvba, Kessel-Lo, Belgium.
  *


### PR DESCRIPTION
This code doesn't look like C at all.