### PR TITLE
Documentation was incorrect for C++

### DIFF
--- a/src/Wt/WComboBox.h
+++ b/src/Wt/WComboBox.h
@@ -184,7 +184,11 @@ public:
 
   /*! \brief Returns the current value.
    *
-   * Returns currentText() converted from a WString to a string.
+   * \if cpp
+   * Returns currentText().
+   * \else
+   * Returns currentText() as a std::string.
+   * \endif
    */
   virtual WT_USTRING valueText() const override;
 


### PR DESCRIPTION
This appears to act differently in C++ vs Java as WT_USTRING is different
in the two environments. The documentation now reflects that.