### PR TITLE
Fix 500 status leading to invalid HTML reply [master]

### DIFF
--- a/src/http/Reply.C
+++ b/src/http/Reply.C
@@ -168,6 +168,7 @@ void toText(S& stream, Reply::status_type status)
   case Reply::no_status:
   case Reply::internal_server_error:
     stream << "500 Internal Server Error\r\n";
+    break;
   default:
     stream << (int) status << " Unknown\r\n";
   }


### PR DESCRIPTION
A missing break was breaking the HTML reply by inserting two status lines instead of only one