### PR TITLE
Fix WStringStream to accept const char strings

### DIFF
--- a/src/Wt/Dbo/StringStream.h
+++ b/src/Wt/Dbo/StringStream.h
@@ -10,6 +10,7 @@
 #include <Wt/WDllDefs.h>
 
 #include <iostream>
+#include <cstring>
 #include <string>
 #include <vector>
 

--- a/src/Wt/WStringStream.C
+++ b/src/Wt/WStringStream.C
@@ -116,13 +116,6 @@ WStringStream& WStringStream::operator<< (char c)
   return *this;
 }
 
-WStringStream& WStringStream::operator<< (char *s)
-{
-  append(s, std::strlen(s));
-
-  return *this;
-}
-
 WStringStream& WStringStream::operator<< (const std::string& s)
 {
   append(s.data(), s.length());

--- a/src/Wt/WStringStream.h
+++ b/src/Wt/WStringStream.h
@@ -8,6 +8,7 @@
 #define WT_WSTRING_STREAM_H_
 
 #include <Wt/WDllDefs.h>
+#include <cstring>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -98,31 +99,18 @@ public:
    */
   void append(const char *s, int length);
 
-#ifndef WT_TARGET_JAVA
-  /*
-   * Should not be implemented but is needed to support the specialization
-   * for string literals !
-   */
-  template <typename T>
-    inline WStringStream& operator<< (T t) {
-    WStringStream please_cast_to_a_supported_type = t;
-    please_cast_to_a_supported_type << 'a'; // silence compiler for normal case
-    return *this;
-  }
-
-  template <std::size_t N>
-    WStringStream& operator<< (const char (&s)[N]) {
-    append(s, N-1); return *this; 
-  }
-#endif // WT_TARGET_JAVA
-
   /*! \brief Appends a character.
    */
   WStringStream& operator<< (char);
 
   /*! \brief Appends a C string.
    */
-  WStringStream& operator<< (char *s);
+  WStringStream& operator<< (const char *s)
+  {
+    append(s, std::strlen(s));
+
+    return *this;
+  }
 
   /*! \brief Appends a C++ string.
    */

--- a/src/web/EscapeOStream.C
+++ b/src/web/EscapeOStream.C
@@ -161,16 +161,6 @@ void EscapeOStream::append(const char *s, std::size_t len)
     put(s, *this);
 }
 
-EscapeOStream& EscapeOStream::operator<< (char *s)
-{
-  if (c_special_ == 0)
-    stream_ << s;
-  else
-    put(s, *this);
-
-  return *this;
-}
-
 void EscapeOStream::append(const std::string& s, const EscapeOStream& rules)
 {
   if (rules.c_special_ == 0)

--- a/src/web/EscapeOStream.h
+++ b/src/web/EscapeOStream.h
@@ -33,22 +33,17 @@ public:
   void append(const std::string& s, const EscapeOStream& rules);
   void append(const char *s, std::size_t len);
 
-#ifndef WT_TARGET_JAVA
-  /*
-   * Should not be implemented but is needed to support the specialization
-   * for string literals !
-   */
-  template <typename T>
-  inline EscapeOStream& operator<< (T t);
-
-  template <std::size_t N>
-    EscapeOStream& operator<< (const char (&s)[N]) {
-    append(s, N-1); return *this; 
-  }
-#endif // WT_TARGET_JAVA
-
   EscapeOStream& operator<< (char);
-  EscapeOStream& operator<< (char *s);
+  EscapeOStream& operator<< (const char *s)
+  {
+    if (c_special_ == 0)
+      stream_ << s;
+    else
+      put(s, *this);
+
+    return *this;
+  }
+
   EscapeOStream& operator<< (const std::string& s);
   EscapeOStream& operator<< (int);
   EscapeOStream& operator<< (long long);


### PR DESCRIPTION
Fix `WStringStream` to directly accept `const char *` strings.  
Remove overly greedy template overload `operator<<`.  
Remove string literal overload to reduce template bloat since there is now a `const char *` overload that can accept string literals.