### PR TITLE
fixes for Linux MinGW (cross-compiling to Windows)

### DIFF
--- a/src/Wt/WLocalDateTime.C
+++ b/src/Wt/WLocalDateTime.C
@@ -19,7 +19,7 @@
 #ifndef WT_WIN32
 #include <ctime>
 #else
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include <chrono>

--- a/src/isapi/IsapiRequest.C
+++ b/src/isapi/IsapiRequest.C
@@ -57,7 +57,7 @@ IsapiRequest::IsapiRequest(LPEXTENSION_CONTROL_BLOCK ecb,
     // Try to configure async mode (synchronous_ must be set right, also
     // if only used for write)
     if (ecb->ServerSupportFunction(ecb->ConnID, HSE_REQ_IO_COMPLETION,
-        &IsapiRequest::completionCallback, 0, (LPDWORD)this)) {
+        (LPVOID)&IsapiRequest::completionCallback, 0, (LPDWORD)this)) {
       // Note: we don't expect this to happen
       synchronous_ = false;
     }

--- a/src/isapi/Server.C
+++ b/src/isapi/Server.C
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <fstream>
+#include <cstring>
 
 using std::exit;
 using std::strcpy;


### PR DESCRIPTION
follow-up on https://github.com/bincrafters/community/issues/353

main change is to use lower-case Windows headers names (e.g. Windows.h -> windows.h, ShlObj.h -> shlobj.h).
and few minor fixes - missing cstring include and implicit function pointer -> data pointer case.

to reproduce the following docker image may be used: https://hub.docker.com/r/bincrafters/docker-mingw-gcc7/