### PR TITLE
WLogEntry to allow ADL to find to_string

### DIFF
--- a/src/Wt/WLogger.h
+++ b/src/Wt/WLogger.h
@@ -320,7 +320,10 @@ public:
   WLogEntry& operator<< (T t) {
     startField();
     if (impl_)
-      impl_->line_ << std::to_string(t);
+    {
+      using std::to_string;
+      impl_->line_ << to_string(t);
+    }
     return *this;
   }
 


### PR DESCRIPTION
This allows a user-defined type to be more easily used with the WLogEntry input stream. A user-defined type just needs to define its own "to_string" in its namespace scope, and then it can be use with WLogEntry via argument-dependent lookup.