### PR TITLE
Fix mysql backend build

### DIFF
--- a/cmake/WtFindMysql.txt
+++ b/cmake/WtFindMysql.txt
@@ -27,6 +27,7 @@ FIND_LIBRARY(MYSQL_LIB
     NAMES
 	${MYSQL_LIBRARY}
     PATHS
+    ${MYSQL_PREFIX}
     ${MYSQL_PREFIX}/lib
     ${MYSQL_PREFIX}/lib/opt
     ${MYSQL_PREFIX}/lib/mysql


### PR DESCRIPTION
This fix helps to specify full path to the mysqlclient library.

For example, on ubuntu 18.04 the path to mysqlclient  is `/usr/lib/x86_64-linux-gnu/`.
This means that in release 4.0,4 I can not build mysq backend. My request helps to fix this issue.