### PR TITLE
struct WT_API Wt::NoClass

### DIFF
--- a/src/Wt/WSignal.h
+++ b/src/Wt/WSignal.h
@@ -23,7 +23,7 @@ class SlotLearnerInterface;
 class WStatelessSlot;
 class JavaScriptEvent;
 
-struct NoClass
+struct WT_API NoClass
 {
   NoClass() { }
   NoClass(const JavaScriptEvent&) { }


### PR DESCRIPTION
On windows with dll usage of WT you have to dllexport/dllimport Wt::NoClass.
Otherwise you get linkage erros...
