### PR TITLE
Updating non-default WLineEdit constructor to match default constructor

### DIFF
--- a/src/Wt/WLineEdit.C
+++ b/src/Wt/WLineEdit.C
@@ -47,6 +47,8 @@ WLineEdit::WLineEdit(const WT_USTRING& text)
     spaceChar_(' '),
     javaScriptDefined_(false)
 {
+  setInline(true);
+  setFormObject(true);
   setText(text);
 }
 


### PR DESCRIPTION
The two WLineEdit constructors result in different behavior which isn't obvious to the user. The default constructor sets `setInline(true)` and `setFormObject(true)` but these settings are not applied when the user passes a string. This PR adds those two lines to the second constructor. 