### PR TITLE
Improved performance of adding rows and columns to the WTable

### DIFF
--- a/src/Wt/WTable.C
+++ b/src/Wt/WTable.C
@@ -103,7 +103,7 @@ WTableRow* WTable::insertRow(int row, std::unique_ptr<WTableRow> tableRow)
     widgetAdded(cell.get());
   }
   rows_.insert(rows_.begin() + row, std::move(tableRow));
-  rows_[row].get()->expand(columnCount());
+  rows_[row].get()->expand(columnCount(), row);
   repaint(RepaintFlag::SizeAffected);
 
   return rows_[row].get();
@@ -113,7 +113,7 @@ WTableColumn* WTable::insertColumn(int column,
 				   std::unique_ptr<WTableColumn> tableColumn)
 {
   for (unsigned i = 0; i < rows_.size(); ++i)
-    rows_[i]->insertColumn(column);
+    rows_[i]->insertColumn(column, i);
 
   if ((unsigned)column <= columns_.size()) {
     if (!tableColumn){

--- a/src/Wt/WTableRow.C
+++ b/src/Wt/WTableRow.C
@@ -26,19 +26,23 @@ WTableRow::WTableRow()
 WTableRow::~WTableRow()
 { }
 
-std::unique_ptr<WTableCell> WTableRow::createCell(int column)
+std::unique_ptr<WTableCell> WTableRow::createCell(int column, int row)
 {
-  if (table_)
-    return table_->createCell(rowNum(), column);
+  if (table_) {
+    if (-1 == row) {
+      row = rowNum();
+    }
+    return table_->createCell(row, column);
+  }
   else
     return std::unique_ptr<WTableCell>(new WTableCell());
 }
 
-void WTableRow::expand(int numCells)
+void WTableRow::expand(int numCells, int row)
 {
   int cursize = cells_.size();
   for (int col = cursize; col < numCells; ++col) {
-    cells_.push_back(createCell(col));
+    cells_.push_back(createCell(col, row));
     WTableCell *cell = cells_.back().get();
     if (table_)
       table_->widgetAdded(cell);
@@ -47,9 +51,9 @@ void WTableRow::expand(int numCells)
   }
 }
 
-void WTableRow::insertColumn(int column)
+void WTableRow::insertColumn(int column, int row)
 {
-  cells_.insert(cells_.begin() + column, createCell(column));
+  cells_.insert(cells_.begin() + column, createCell(column, row));
   WTableCell *cell = cells_[column].get();
   if (table_)
     table_->widgetAdded(cell);

--- a/src/Wt/WTableRow.h
+++ b/src/Wt/WTableRow.h
@@ -136,10 +136,10 @@ public:
   virtual const std::string id() const override;
 
 protected:
-  virtual std::unique_ptr<WTableCell> createCell(int column);
+  virtual std::unique_ptr<WTableCell> createCell(int column, int row = -1);
 
 private:
-  void expand(int numCells);
+  void expand(int numCells, int row = -1);
 
   WTable *table_;
   std::vector<std::unique_ptr<WTableCell> > cells_;
@@ -151,7 +151,7 @@ private:
 
   void updateDom(DomElement& element, bool all);
   void setTable(WTable *table);
-  void insertColumn(int column);
+  void insertColumn(int column, int row = -1);
   std::unique_ptr<WTableCell> removeColumn(int column);
 
   void undoHide();


### PR DESCRIPTION
The issue was the calling of `WTableRow::rowNum()` for every added cell,
which iterated over the whole table.

The methods `WTableRow::createCell()`, `WTableRow::insertColumn()` and
`WTableRow::expand()` got the new row argument defaulting to -1 that
`WTable` can use when creating new elements with `WTable::insertRow()` and
`WTable::insertColumn()`. These methods are called by `WTable::expand()`
so the performance improvement affects every operation that expands
the table.

The performance of populating a new table row by row is increased
with this commit from O(n^2+n) to O(n).