### PR TITLE
Do not write to std::cerr when opening log file successfully

### DIFF
--- a/src/Wt/WLogger.C
+++ b/src/Wt/WLogger.C
@@ -255,9 +255,6 @@ void WLogger::setFile(const std::string& path)
 #endif
   
   if (ofs->is_open()) {
-    std::cerr 
-      << "INFO: Opened log file (" << path.c_str() << ")." 
-      << std::endl;
     o_ = ofs;
     ownStream_ = true;
   } else {


### PR DESCRIPTION
Since we have opened the file successfully, it seems there isn't a lot of value in logging, and in particular logging to std::err. The logic is detailed more clearly in this ticket [1].

[1] https://redmine.emweb.be/issues/7240