### PR TITLE
CMake is not able to find boost components using wt-config.cmake

### DIFF
--- a/wt-config.cmake.in
+++ b/wt-config.cmake.in
@@ -3,7 +3,7 @@ if(@_WTCONFIG_CMAKE_FIND_BOOST@)
   set(Boost_USE_STATIC_LIBS @_WTCONFIG_BOOST_STATIC@)
   set(Boost_USE_MULTITHREADED @Boost_USE_MULTITHREADED@)
   find_package(Boost QUIET
-    COMPONENTS "@Boost_COMPONENTS@")
+    COMPONENTS @Boost_COMPONENTS@)
 endif()
 
 # Required target


### PR DESCRIPTION
The expression
```
find_package(Boost QUIET COMPONENTS "@Boost_COMPONENTS@")
```
results in
```
find_package(Boost QUIET COMPONENTS "program_options;filesystem;thread")
```
according to the CMake documentation [1] and [2] is a list with one entry `"program_options;filesystem;thread"` and CMake is unable to find the component `"program_options;filesystem;thread"`

The correct form is
```
find_package(Boost QUIET COMPONENTS program_options;filesystem;thread)
```
Then CMake interprets `program_options;filesystem;thread` as a list with three entries.

[1] https://cmake.org/cmake/help/latest/command/find_package.html?highlight=components
[2] https://cmake.org/cmake/help/latest/command/list.html