### PR TITLE
Perfect forwarding for Signal parameters

### DIFF
--- a/src/Wt/Signals/signals.hpp
+++ b/src/Wt/Signals/signals.hpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <functional>
 #include <vector>
+#include <utility>
 
 namespace Wt { namespace Signals { namespace Impl {
 
@@ -239,7 +240,7 @@ public:
       do {
         if (link->active()) {
           try {
-            link->function(args...);
+            link->function(std::forward<Args>(args) ...);
           } catch (...) {
             link->decref();
 
@@ -327,7 +328,7 @@ struct ConnectHelper {
 			    T *target, void (V::*method)(B...))
   { 
     return signal.connect
-      ([target, method](Args... a) { (target ->* method) (a...); },
+      ([target, method](Args... a) { (target ->* method) (std::forward<Args>(a)...); },
        target);
   }
 };
@@ -368,7 +369,7 @@ struct ConnectHelper<1, Args...> {
   {
     return signal.connect
       ([target, method](B1 b1, An...) {
-	(target ->* method) (b1);
+        (target ->* method) (std::forward<B1>(b1));
       }, target);
   }
 };
@@ -390,7 +391,7 @@ struct ConnectHelper<2, Args...> {
   {
     return signal.connect
       ([target, method](B1 b1, B2 b2, An...) {
-	(target ->* method) (b1, b2);
+        (target ->* method) (std::forward<B1>(b1), std::forward<B2>(b2));
       }, target);
   }
 };
@@ -415,7 +416,7 @@ struct ConnectHelper<3, Args...> {
   {
     return signal.connect
       ([target, method](B1 b1, B2 b2, B3 b3, An...) {
-	(target ->* method) (b1, b2, b3);
+        (target ->* method) (std::forward<B1>(b1), std::forward<B2>(b2), std::forward<B3>(b3));
       }, target);
   }
 };

--- a/src/Wt/WSignal.h
+++ b/src/Wt/WSignal.h
@@ -15,6 +15,7 @@
 #endif // WT_TARGET_JAVA
 
 #include <functional>
+#include <utility>
 
 namespace Wt {
 
@@ -752,13 +753,13 @@ Wt::Signals::connection Signal<A...>
 template <class... A>
 void Signal<A...>::emit(A... args) const
 {
-  impl_.emit(args...);
+  impl_.emit(std::forward<A>(args)...);
 }
 
 template <class... A>
 void Signal<A...>::operator()(A... args) const
 {
-  emit(args...);
+  emit(std::forward<A>(args)...);
 }
 
 template <class... A>


### PR DESCRIPTION
This fix allows you to pass move-only objects as signal parameters. To do this, they are wrapped in std::forward(). In other words the parameters are perfectly forwarded.

An example use cases where this can be useful:

**Example emiting:**
`button->clicked().connect(
[this] { my_signal.emit(std::make_unique<Wt::WText>("Send this text widget by a signal")); });`


**Example Slot :**

`void contentLoad(std::unique_ptr<Wt::WWidget> widget)
{
  root()->addWidget(std::move(widget));
}`
