### PR TITLE
Resolved an issue with DBO_EXTERN_TEMPLATES and DBO_INSTANTIATE_TEMPLATES 

### DIFF
--- a/src/Wt/Dbo/Impl.h
+++ b/src/Wt/Dbo/Impl.h
@@ -28,7 +28,7 @@
 				 Wt::Dbo::DynamicBinding >;		\
   template class Wt::Dbo::Query< Wt::Dbo::ptr<C>,			\
 				 Wt::Dbo::DirectBinding >;		\
-  template class Wt::Dbo::query_result_traits< Wt::Dbo::ptr<C> >;       \
+  template struct Wt::Dbo::query_result_traits< Wt::Dbo::ptr<C> >;       \
   template Wt::Dbo::ptr<C> Wt::Dbo::Session::add<C>(ptr<C>&);		\
   template Wt::Dbo::ptr<C> Wt::Dbo::Session::add<C>(std::unique_ptr<C>);\
   template Wt::Dbo::ptr<C> Wt::Dbo::Session::load<C>			\

--- a/src/Wt/Dbo/Types.h
+++ b/src/Wt/Dbo/Types.h
@@ -28,7 +28,7 @@
 					Wt::Dbo::DynamicBinding >;	\
   extern template class Wt::Dbo::Query< Wt::Dbo::ptr<C>,		\
 					Wt::Dbo::DirectBinding >;	\
-  extern template class Wt::Dbo::query_result_traits< Wt::Dbo::ptr<C> >;\
+  extern template struct Wt::Dbo::query_result_traits< Wt::Dbo::ptr<C> >;\
   extern template Wt::Dbo::ptr<C> Wt::Dbo::Session::add<C>(ptr<C>&);	\
   extern template Wt::Dbo::ptr<C> Wt::Dbo::Session::add<C>(std::unique_ptr<C>);	\
   extern template Wt::Dbo::ptr<C> Wt::Dbo::Session::load<C>		\


### PR DESCRIPTION
The Wt::Dbo::query_result_traits<> template was declared and defined as 'struct' in SqlTraits.h, but is declared as 'class' in the DBO_EXTERN_TEMPLATES and DBO_INSTANTIATE_TEMPLATES macros. This inconsistency causes multiple compiler warnings, such as [C4099](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4099?view=msvc-160) on Visual Studio 2017/2019., whenever the macros are used. Declaring as struct solves the issue.