### PR TITLE
Fixed several issues in Wt::Dbo::collection<>

### DIFF
--- a/src/Wt/Dbo/collection.h
+++ b/src/Wt/Dbo/collection.h
@@ -122,9 +122,16 @@ namespace Wt {
 
     /*! \brief Iterator.
      */
-    class iterator : public std::iterator<std::input_iterator_tag, C>
+    class iterator
     {
     public:
+
+      typedef std::input_iterator_tag iterator_category;
+      typedef                       C value_type;
+      typedef          std::ptrdiff_t difference_type;
+      typedef             value_type *pointer;
+      typedef             value_type& reference;
+
       /*! \brief Copy constructor.
        */
       iterator(const iterator& other);
@@ -195,9 +202,16 @@ namespace Wt {
 
     /*! \brief Const Iterator.
      */
-    class const_iterator : public std::iterator<std::input_iterator_tag, C>
+    class const_iterator
     {
     public:
+
+      typedef std::input_iterator_tag iterator_category;
+      typedef                       C value_type;
+      typedef          std::ptrdiff_t difference_type;
+      typedef             value_type *pointer;
+      typedef             value_type& reference;
+
       /*! \brief Copy constructor.
        */
       const_iterator(const const_iterator& other);

--- a/src/Wt/Dbo/collection_impl.h
+++ b/src/Wt/Dbo/collection_impl.h
@@ -110,7 +110,7 @@ bool collection<C>::iterator::operator== (const iterator& other) const
 {
   return impl_ == other.impl_
     || (!impl_ && other.impl_->ended_)
-    || (impl_->ended_ && !other.impl_);
+    || (impl_ && impl_->ended_ && !other.impl_);
 }
 
 template <class C>

--- a/src/Wt/Dbo/collection_impl.h
+++ b/src/Wt/Dbo/collection_impl.h
@@ -531,11 +531,11 @@ typename collection<C>::size_type collection<C>::size() const
     }
 
     if (type_ != QueryCollection) {
-      result += manualModeInsertions_.size();
-      result -= manualModeRemovals_.size();
+      result += static_cast<int>(manualModeInsertions_.size());
+      result -= static_cast<int>(manualModeRemovals_.size());
     }
 
-    return result;
+    return static_cast<typename collection<C>::size_type>(result);
   } else
     return 0;
 }
@@ -697,13 +697,13 @@ int collection<C>::count(C c) const
 
   Query<C, DynamicBinding> q = find().where(mapping->idCondition);
   c.obj()->bindId(q.parameters_);
-  int result = q.resultList().size();
+  std::size_t result = q.resultList().size();
 
   result += 
     std::count(manualModeInsertions_.begin(), manualModeInsertions_.end(), c);
   result -=
     std::count(manualModeRemovals_.begin(), manualModeRemovals_.end(), c);
-  return result;
+  return static_cast<int>(result);
 }
 
 template <class C>

--- a/src/Wt/Dbo/collection_impl.h
+++ b/src/Wt/Dbo/collection_impl.h
@@ -230,6 +230,15 @@ collection<C>::const_iterator::operator= (const const_iterator& other)
 }
 
 template <class C>
+typename collection<C>::const_iterator&
+collection<C>::const_iterator::operator= (const iterator& other)
+{
+  impl_ = other;
+
+  return *this;
+}
+
+template <class C>
 C
 collection<C>::const_iterator::operator* ()
 {

--- a/test/dbo/DboTest.C
+++ b/test/dbo/DboTest.C
@@ -3297,4 +3297,38 @@ BOOST_AUTO_TEST_CASE( dbo_test42 )
 #endif // POSTGRES
 }
 
+BOOST_AUTO_TEST_CASE( dbo_test43 )
+{
+  // Test for collection iterator's operator== for pull request #177
+  // This will crash without that patch
+  DboFixture f;
+  dbo::Session &session = *f.session_;
+
+  {
+    dbo::Transaction t(session);
+    dbo::ptr<B> b1 = session.addNew<B>();
+    b1.modify()->name = "Test1";
+    dbo::ptr<B> b2 = session.addNew<B>();
+    b2.modify()->name = "Test2";
+  }
+
+  {
+    dbo::Transaction t(session);
+
+    dbo::collection<dbo::ptr<B>> collection = session.find<B>().resultList();
+
+    auto begin = collection.begin();
+    auto end = collection.end();
+
+    BOOST_REQUIRE(begin == begin);
+    BOOST_REQUIRE(!(begin != begin));
+    BOOST_REQUIRE(end == end);
+    BOOST_REQUIRE(!(end != end));
+    BOOST_REQUIRE(!(begin == end));
+    BOOST_REQUIRE(begin != end);
+    BOOST_REQUIRE(!(end == begin));
+    BOOST_REQUIRE(end != begin);
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pull request covers/fixes several issues with Wt::Dbo::collection<>:

- The collection::iterator operator == may cause an access violation due to a missing null-check in the third case; this can occur if impl_ == nullptr && other.impl_ != nullptr && other.impl_.ended_ == false, which is not covered by the first 2 cases.
- collection::iterator and collection::const_iterator are derived from std::iterator, which is deprecated in C++17. Since deriving from std::iterator does nothing but adding some type definitions, adding those typedefs directly to iterator/const_iterator solves the deprecation issue while being fully compatible with C++14 and before.
- const_iterator declares the assignment operator operator = (iterator), but the definition is missing. I added one which mimics the behavior of the const_iterator(iterator) constructor.
- There were some 32/64bit signed/unsigned type conversion issues in collection::size() and count() functions. I added some static_casts to resolve the numerous warnings caused by this, though i suggest a more thorough fix for the issue