### PR TITLE
Fix float formatting in web utils

### DIFF
--- a/src/web/WebUtils.C
+++ b/src/web/WebUtils.C
@@ -254,7 +254,8 @@ namespace {
     }
 
     static int floatfield(T t) {
-      return (t != 0.0) && ((t < 0.001) || (t > 1E8)) ?
+      T abs_t = std::abs(t);
+      return (t != 0.0) && ((abs_t < 0.001) || (abs_t > 1E8)) ?
 	karma::real_policies<T>::fmtflags::scientific :
 	karma::real_policies<T>::fmtflags::fixed;
     }


### PR DESCRIPTION
Before any negative number would be rendered as a scientific number in javascript.
I think this is more in line with the intention, which will render
numerically very small and very large numbers as scientific.

Here is an example of rendered javascript before and after
before:
`ctx.moveTo(-8.6e00,-1.4e01);ctx.lineTo(8.6,-1.4e01);ctx.lineTo(8.6,14.0);ctx.lineTo(-8.6e00,14.0);ctx.lineTo(-8.6e00,-1.4e01);`
after:
`ctx.moveTo(-8.6,-14.0);ctx.lineTo(8.6,-14.0);ctx.lineTo(8.6,14.0);ctx.lineTo(-8.6,14.0);ctx.lineTo(-8.6,-14.0);`

I think the second one is more correct.