### PR TITLE
Added support for long in json

### DIFF
--- a/src/Wt/Json/Value.C
+++ b/src/Wt/Json/Value.C
@@ -278,22 +278,6 @@ Value::operator int() const
     throw TypeException(type(), Type::Number);
 }
 
-Value::operator long long() const
-{
-  const std::type_info& t = v_.type();
-
-  if (t == typeid(double))
-    return static_cast<long long>(cpp17::any_cast<double>(v_));
-  else if (t == typeid(long))
-    return static_cast<long long>(cpp17::any_cast<long>(v_));
-  else if (t == typeid(long long))
-    return cpp17::any_cast<long long>(v_);
-  else if (t == typeid(int))
-    return static_cast<long long>(cpp17::any_cast<int>(v_));
-  else
-    throw TypeException(type(), Type::Number);
-}
-
 Value::operator long() const
 {
   const std::type_info& t = v_.type();
@@ -306,6 +290,22 @@ Value::operator long() const
     return static_cast<long>(cpp17::any_cast<long long>(v_));
   else if (t == typeid(int))
     return static_cast<long>(cpp17::any_cast<int>(v_));
+  else
+    throw TypeException(type(), Type::Number);
+}
+
+Value::operator long long() const
+{
+  const std::type_info& t = v_.type();
+
+  if (t == typeid(double))
+    return static_cast<long long>(cpp17::any_cast<double>(v_));
+  else if (t == typeid(long))
+    return static_cast<long long>(cpp17::any_cast<long>(v_));
+  else if (t == typeid(long long))
+    return cpp17::any_cast<long long>(v_);
+  else if (t == typeid(int))
+    return static_cast<long long>(cpp17::any_cast<int>(v_));
   else
     throw TypeException(type(), Type::Number);
 }

--- a/src/Wt/Json/Value.C
+++ b/src/Wt/Json/Value.C
@@ -102,6 +102,11 @@ Value::Value(int value)
   : v_(value)
 { }
 
+Value::Value(long value)
+  : v_(value)
+{ }
+
+
 Value::Value(long long value)
   : v_(value)
 { }
@@ -190,6 +195,8 @@ bool Value::operator== (const Value& other) const
     return cpp17::any_cast<bool>(v_) == cpp17::any_cast<bool>(other.v_);
   else if (v_.type() == typeid(int))
     return cpp17::any_cast<int>(v_) == cpp17::any_cast<int>(other.v_);
+  else if (v_.type() == typeid(long))
+    return cpp17::any_cast<long>(v_) == cpp17::any_cast<long>(other.v_);
   else if (v_.type() == typeid(long long))
     return cpp17::any_cast<long long>(v_) ==
       cpp17::any_cast<long long>(other.v_);
@@ -227,7 +234,7 @@ Type Value::typeOf(const std::type_info& t)
 {
   if (t == typeid(bool))
     return Type::Bool;
-  else if (t == typeid(double) || t == typeid(long long) || t == typeid(int))
+  else if (t == typeid(double) || t == typeid(long long) || t == typeid(int) || t == typeid(long))
     return Type::Number;
   else if (t == typeid(WT_USTRING))
     return Type::String;
@@ -261,6 +268,8 @@ Value::operator int() const
 
   if (t == typeid(double))
     return static_cast<int>(cpp17::any_cast<double>(v_));
+  else if (t == typeid(long))
+    return static_cast<int>(cpp17::any_cast<long>(v_));
   else if (t == typeid(long long))
     return static_cast<int>(cpp17::any_cast<long long>(v_));
   else if (t == typeid(int))
@@ -275,10 +284,28 @@ Value::operator long long() const
 
   if (t == typeid(double))
     return static_cast<long long>(cpp17::any_cast<double>(v_));
+  else if (t == typeid(long))
+    return static_cast<long long>(cpp17::any_cast<long>(v_));
   else if (t == typeid(long long))
     return cpp17::any_cast<long long>(v_);
   else if (t == typeid(int))
     return static_cast<long long>(cpp17::any_cast<int>(v_));
+  else
+    throw TypeException(type(), Type::Number);
+}
+
+Value::operator long() const
+{
+  const std::type_info& t = v_.type();
+
+  if (t == typeid(double))
+    return static_cast<long>(cpp17::any_cast<double>(v_));
+  else if (t == typeid(long))
+    return cpp17::any_cast<long>(v_);
+  else if (t == typeid(long long))
+    return static_cast<long>(cpp17::any_cast<long long>(v_));
+  else if (t == typeid(int))
+    return static_cast<long>(cpp17::any_cast<int>(v_));
   else
     throw TypeException(type(), Type::Number);
 }
@@ -289,6 +316,8 @@ Value::operator double() const
 
   if (t == typeid(double))
     return cpp17::any_cast<double>(v_);
+  else if (t == typeid(long))
+    return static_cast<double>(cpp17::any_cast<long>(v_));
   else if (t == typeid(long long))
     return static_cast<double>(cpp17::any_cast<long long>(v_));
   else if (t == typeid(int))
@@ -431,7 +460,7 @@ Value Value::toNumber() const
 
   if (t == typeid(Object) || t == typeid(Array))
     return Null;
-  else if (t == typeid(double) || t == typeid(long long) || t == typeid(int))
+  else if (t == typeid(double) || t == typeid(long long) || t == typeid(int) || t == typeid(long))
     return *this;
   else if (t == typeid(WT_USTRING)) {
     const WT_USTRING& s = cpp17::any_cast<const WT_USTRING& >(v_);

--- a/src/Wt/Json/Value.h
+++ b/src/Wt/Json/Value.h
@@ -143,6 +143,13 @@ public:
    * This creates a \link Wt::Json::Type::Number
    * Json::Type::Number\endlink value.
    */
+  Value(long value);
+
+  /*! \brief Creates a value from a long long.
+   *
+   * This creates a \link Wt::Json::Type::Number
+   * Json::Type::Number\endlink value.
+   */
   Value(long long value);
 
   /*! \brief Creates a value from a double.
@@ -432,6 +439,37 @@ public:
    * Json::Type::Number\endlink
    */
   operator long long() const;
+
+  /*! \brief Extracts the integer number value.
+   *
+   * This returns the value of a \link Wt::Json::Type::Number
+   * number \endlink JSON value.
+   *
+   * For example:
+   * \code
+   * const Json::Object& person = ...;
+   * try {
+   *   long cost = person.get("cost");
+   *   ...
+   * } catch (const std::exception& e) {
+   *   ...
+   * }
+   * \endcode
+   *
+   * To coerce a value of another type to a number use toNumber()
+   * first. To provide a fallback in case the value is null or could
+   * not be coerced to a number, use orIfNull().
+   *
+   * For example, the following code does not throw exceptions:
+   * \code
+   * const Json::Object& person = ...;
+   * long cost = person.get("cost").toNumber().orIfNull(0LL);
+   * \endcode
+   *
+   * \throws TypeException if the value type is not \link Wt::Json::Type::Number
+   * Json::Type::Number\endlink
+   */
+  operator long() const;
 
   /*! \brief Extracts the floating point number value.
    *

--- a/src/Wt/Json/Value.h
+++ b/src/Wt/Json/Value.h
@@ -418,6 +418,38 @@ public:
    * \code
    * const Json::Object& person = ...;
    * try {
+   *   long cost = person.get("cost");
+   *   ...
+   * } catch (const std::exception& e) {
+   *   ...
+   * }
+   * \endcode
+   *
+   * To coerce a value of another type to a number use toNumber()
+   * first. To provide a fallback in case the value is null or could
+   * not be coerced to a number, use orIfNull().
+   *
+   * For example, the following code does not throw exceptions:
+   * \code
+   * const Json::Object& person = ...;
+   * long cost = person.get("cost").toNumber().orIfNull(0L);
+   * \endcode
+   *
+   * \throws TypeException if the value type is not \link Wt::Json::Type::Number
+   * Json::Type::Number\endlink
+   */
+  operator long() const;
+
+  
+  /*! \brief Extracts the integer number value.
+   *
+   * This returns the value of a \link Wt::Json::Type::Number
+   * number \endlink JSON value.
+   *
+   * For example:
+   * \code
+   * const Json::Object& person = ...;
+   * try {
    *   long long cost = person.get("cost");
    *   ...
    * } catch (const std::exception& e) {
@@ -439,37 +471,6 @@ public:
    * Json::Type::Number\endlink
    */
   operator long long() const;
-
-  /*! \brief Extracts the integer number value.
-   *
-   * This returns the value of a \link Wt::Json::Type::Number
-   * number \endlink JSON value.
-   *
-   * For example:
-   * \code
-   * const Json::Object& person = ...;
-   * try {
-   *   long cost = person.get("cost");
-   *   ...
-   * } catch (const std::exception& e) {
-   *   ...
-   * }
-   * \endcode
-   *
-   * To coerce a value of another type to a number use toNumber()
-   * first. To provide a fallback in case the value is null or could
-   * not be coerced to a number, use orIfNull().
-   *
-   * For example, the following code does not throw exceptions:
-   * \code
-   * const Json::Object& person = ...;
-   * long cost = person.get("cost").toNumber().orIfNull(0LL);
-   * \endcode
-   *
-   * \throws TypeException if the value type is not \link Wt::Json::Type::Number
-   * Json::Type::Number\endlink
-   */
-  operator long() const;
 
   /*! \brief Extracts the floating point number value.
    *


### PR DESCRIPTION
I don't see why JSON does not support long values.
I added a constructor that supports long values and the associated code.