### PR TITLE
Correct documented invocation

### DIFF
--- a/src/Wt/WServer.h
+++ b/src/Wt/WServer.h
@@ -57,7 +57,7 @@ int WRun(int argc, char *argv[], ApplicationCreator createApplication)
     // by the server configuration's deploy-path)
     server.addEntryPoint(Wt::EntryPointType::Application, createApplication);
     if (server.start()) {
-      int sig = WServer::waitForShutdown(argv[0]);
+      int sig = WServer::waitForShutdown();
 
       std::cerr << "Shutdown (signal = " << sig << ")" << std::endl;
       server.stop();


### PR DESCRIPTION
WServer::waitForShutdown doesn't take a parameter.