### PR TITLE
Fixed a possible access violation in WebSession

### DIFF
--- a/src/web/WebSession.C
+++ b/src/web/WebSession.C
@@ -680,9 +680,15 @@ bool WebSession::start(WebResponse *response)
 {
   try {
     app_ = controller_->doCreateApplication(this).release();
-    if (!app_->internalPathValid_)
-      if (response->responseType() == WebResponse::ResponseType::Page)
-        response->setStatus(404);
+    if (app_) {
+      if (!app_->internalPathValid_) {
+        if (response->responseType() == WebResponse::ResponseType::Page) {
+          response->setStatus(404);
+        }
+      }
+    } else {
+      throw WException("WebSession::start: ApplicationCreator returned a nullptr");
+    }
   } catch (std::exception& e) {
     app_ = nullptr;
 


### PR DESCRIPTION
This pull request contains a fix for a segmentation fault during application creation, if the application create function used for an entry point returns a nullptr - as described in [Issue 10483](https://redmine.webtoolkit.eu/issues/10483).