### PR TITLE
Added missing timeout default initialization in FixedSqlConnectionPool

### DIFF
--- a/src/Wt/Dbo/FixedSqlConnectionPool.C
+++ b/src/Wt/Dbo/FixedSqlConnectionPool.C
@@ -29,7 +29,7 @@ struct FixedSqlConnectionPool::Impl {
   std::condition_variable connectionAvailable;
 #endif // WT_THREADED
 
-  std::chrono::steady_clock::duration timeout;
+  std::chrono::steady_clock::duration timeout{ std::chrono::steady_clock::duration::zero() };
   std::vector<std::unique_ptr<SqlConnection>> freeList;
 };
 


### PR DESCRIPTION
This pull request contains a fix for the missing timeout default initialization in `FixedSqlConnectionPool` - as described in [Issue 10543](https://redmine.webtoolkit.eu/issues/10543).