### PR TITLE
Touch up documentation on Wt::WSignal

### DIFF
--- a/src/Wt/WSignal.h
+++ b/src/Wt/WSignal.h
@@ -166,8 +166,10 @@ private:
  * the same parameters in the member function, or less (leaving out
  * parameters at the end).
  *
- * The signal automatically disconnects from the slot when the
- * target is deleted. In addition, the signal may be deleted at any
+ * When the receiver function is an object method, the signal will
+ * automatically be disconnected when the object is deleted, as long
+ * as the object inherits from WObject (or Wt::Core::observable).
+ * In addition, the signal may be deleted at any
  * time, in particular also while it is being emitted.
  *
  * \if cpp


### PR DESCRIPTION
The documentation was missing qualifications concerning under which conditions the signal would NOT be disconnected. That is, for instance if you pass a lambda function object (which doesn't inherit from `Wt::Core::observable`), `Wt::WSignal` has no way to unregister or disconnect the signal.