### PR TITLE
Fix WTreeView loading. See #11240

### DIFF
--- a/src/Wt/WTreeView.C
+++ b/src/Wt/WTreeView.C
@@ -1739,7 +1739,7 @@ bool WTreeView::isExpandedRecursive(const WModelIndex& index) const
     if (index != rootIndex())
       return isExpanded(index.parent());
     else
-      return false;
+      return true;
   } else
     return false;
 }


### PR DESCRIPTION
When rows are removed, `WTreeView::modelRowsAboutToBeRemoved` calls `isExpandedRecursive` to determine if rendered tree nodes are impacted by the removal. However, `isExpandedRecursive` was always returning false for the root node. This seems odd, when the root node is always expanded. This behaviour caused a bug because the `removedHeight_` was not being set. This lead to the `childrenHeight` not being updated, and the loading isn't triggered.

Switching  `isExpandedRecursive`  to true for the root index fixes the issue ... but maybe it was intentionally set like this, but I can't see why.