### PR TITLE
Support for C++20 u8string

### DIFF
--- a/src/Wt/WString.C
+++ b/src/Wt/WString.C
@@ -67,6 +67,13 @@ WString::WString(const std::u32string &value)
   utf8_ = Wt::toUTF8(value);
 }
 
+#ifdef __cpp_char8_t
+WString::WString(const std::u8string& value)
+{
+  utf8_ = std::string(value.begin(), value.end());
+}
+#endif
+
 WString::WString(const char *value, CharEncoding encoding)
   : impl_(nullptr)
 {
@@ -184,6 +191,16 @@ WString& WString::operator+= (const std::wstring& rhs)
 
   return *this;
 }
+
+#ifdef __cpp_char8_t
+WString& WString::operator+=(const std::u8string& rhs)
+{
+  makeLiteral();
+  utf8_ += std::string(rhs.begin(), rhs.end());
+
+  return *this;
+}
+#endif
 
 WString& WString::operator+= (const std::u16string& rhs)
 {
@@ -432,6 +449,14 @@ WString::operator std::wstring() const
   return value();
 }
 
+#ifdef __cpp_char8_t
+WString::operator std::u8string() const
+{
+  std::u8string ret(utf8_.begin(), utf8_.end());
+  return ret;
+}
+#endif
+
 WString::operator std::u16string() const
 {
   return toUTF16();
@@ -625,6 +650,14 @@ WString operator+ (const WString& lhs, const std::wstring& rhs)
   return result += rhs;
 }
 
+#ifdef __cpp_char8_t
+WString operator+(const WString& lhs, const std::u8string& rhs)
+{
+  WString result = lhs;
+  return result += rhs;
+}
+#endif
+
 WString operator+ (const WString& lhs, const std::u16string& rhs)
 {
   WString result = lhs;
@@ -730,6 +763,13 @@ bool operator== (const std::wstring& lhs, const WString& rhs)
   return WString(lhs) == rhs;
 }
 
+#ifdef __cpp_char8_t
+bool operator==(const std::u8string& lhs, const WString& rhs)
+{
+  return WString(lhs) == rhs;
+}
+#endif
+
 bool operator== (const std::u16string& lhs, const WString& rhs)
 {
   return WString(lhs) == rhs;
@@ -769,6 +809,13 @@ bool operator!= (const std::wstring& lhs, const WString& rhs)
 {
   return WString(lhs) != rhs;
 }
+
+#ifdef __cpp_char8_t
+bool operator!=(const std::u8string& lhs, const WString& rhs)
+{
+  return WString(lhs) != rhs;
+}
+#endif
 
 bool operator!= (const std::u16string& lhs, const WString& rhs)
 {

--- a/src/Wt/WString.h
+++ b/src/Wt/WString.h
@@ -180,6 +180,11 @@ public:
   WString(const std::string& value,
           CharEncoding encoding = CharEncoding::Default);
 
+
+#ifdef __cpp_char8_t
+  WString(const std::u8string& value);
+#endif
+
   /*! \brief Creates a %WString from a C++ string.
    *
    * The C++ string is implicitly converted to unicode. When
@@ -264,6 +269,18 @@ public:
    * string using the current WLocale.
    */
   WString& operator+= (const std::wstring& rhs);
+
+
+  /*! \brief Self-concatenation operator
+   *
+   * Appends a string to the current value. If the string was localized,
+   * this automatically converts it to a literal string, by evaluating the
+   * string using the current WLocale.
+   */
+
+#ifdef __cpp_char8_t
+  WString& operator+= (const std::u8string& rhs);
+#endif
 
 #ifndef WT_TARGET_JAVA
   /*! \brief Self-concatenation operator
@@ -489,6 +506,16 @@ public:
    * Argument place holders are substitued with actual arguments.
    */
   operator std::wstring() const;
+
+  /*! \brief Returns the value as a C++20 u8string.
+ *
+ * A localized string is resolved using the WApplication::localizedStrings().
+ *
+ * Argument place holders are substitued with actual arguments.
+ */
+#ifdef __cpp_char8_t
+  operator std::u8string() const;
+#endif
 
 #ifndef WT_TARGET_JAVA
   /*! \brief Returns the value as a UTF-16 C++ string.
@@ -789,6 +816,15 @@ extern WT_API WString operator+ (const WString& lhs, const WString& rhs);
  */
 extern WT_API WString operator+ (const WString& lhs, const std::wstring& rhs);
 
+
+/*! \brief Conatenate a WString with a C++ u8string
+ *
+ * \relates WString
+ */
+#ifdef __cpp_char8_t
+extern WT_API WString operator+ (const WString& lhs, const std::u8string& rhs);
+#endif
+
 /*! \brief Conatenate a WString with a C++ UTF-16 string
  *
  * \relates WString
@@ -915,6 +951,15 @@ extern WT_API bool operator== (const std::string& lhs, const WString& rhs);
  */
 extern WT_API bool operator== (const std::wstring& lhs, const WString& rhs);
 
+
+/*! \brief Compare a C++ u8string with a WString
+ *
+ * \relates WString
+ */
+#ifdef __cpp_char8_t
+extern WT_API bool operator== (const std::u8string& lhs, const WString& rhs);
+#endif
+
 /*! \brief Compare a C++ UTF-16 string with a WString
  *
  * \relates WString
@@ -962,6 +1007,14 @@ extern WT_API bool operator!= (const std::string& lhs, const WString& rhs);
  * \relates WString
  */
 extern WT_API bool operator!= (const std::wstring& lhs, const WString& rhs);
+
+/*! \brief Compare a C++ wide string with a WString
+ *
+ * \relates WString
+ */
+#ifdef __cpp_char8_t
+extern WT_API bool operator!= (const std::u8string& lhs, const WString& rhs);
+#endif
 
 /*! \brief Compare a C++ UTF-16 string with a WString
  *


### PR DESCRIPTION
Since WString already stored utf8_ as std::string. This is just additional interfaces for accepting std::u8string arguments. No conversion needed.

![image](https://user-images.githubusercontent.com/8325019/218640962-243715ea-4c3d-4018-a22f-da3e10632fae.png)
https://en.cppreference.com/w/cpp/language/types#char8_t