### PR TITLE
Handle enableAjax for WCarthesianChart when progressive bootstrap is enabled

### DIFF
--- a/src/Wt/Chart/WCartesianChart.C
+++ b/src/Wt/Chart/WCartesianChart.C
@@ -1395,6 +1395,7 @@ WCartesianChart::WCartesianChart()
     onDemandLoadingEnabled_(false),
     loadingBackground_(StandardColor::LightGray),
     cObjCreated_(false),
+    hasAjax_(false),
     jsSeriesSelected_(this, "seriesSelected"),
     loadTooltip_(this, "loadTooltip")
 {
@@ -1425,6 +1426,7 @@ WCartesianChart::WCartesianChart(ChartType type)
     onDemandLoadingEnabled_(false),
     loadingBackground_(StandardColor::LightGray),
     cObjCreated_(false),
+    hasAjax_(false),
     jsSeriesSelected_(this, "seriesSelected"),
     loadTooltip_(this, "loadTooltip")
 {
@@ -1440,6 +1442,33 @@ WCartesianChart::~WCartesianChart()
   for (std::size_t i = 0; i < copy.size(); ++i) {
     copy[i]->setSeries(nullptr);
   }
+}
+
+void WCartesianChart::enableAjax()
+{
+  WAbstractChart::enableAjax();
+  if (!hasAjax_) {
+    enableEventHandlers();
+  }
+  hasAjax_ = true;
+}
+
+// Needs ajax enabled
+void WCartesianChart::enableEventHandlers()
+{
+  mouseWentDown().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseDown(o, e);}}");
+  mouseWentUp().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseUp(o, e);}}");
+  mouseDragged().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseDrag(o, e);}}");
+  mouseMoved().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseMove(o, e);}}");
+  mouseWheel().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseWheel(o, e);}}");
+  mouseWentOut().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseOut(o, e);}}");
+  touchStarted().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.touchStart(o, e);}}");
+  touchEnded().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.touchEnd(o, e);}}");
+  touchMoved().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.touchMoved(o, e);}}");
+  clicked().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.clicked(o, e);}}");
+  jsSeriesSelected_.connect(this, &WCartesianChart::jsSeriesSelected);
+  loadTooltip_.connect(this, &WCartesianChart::loadTooltip);
+  voidEventSignal("dragstart", true)->preventDefaultAction(true);
 }
 
 void WCartesianChart::init()
@@ -1475,20 +1504,9 @@ void WCartesianChart::init()
     yAxes_[i].transformChanged.reset(new JSignal<>(this, "yTransformChanged" + std::to_string(i)));
   }
 
-  if (WApplication::instance() && WApplication::instance()->environment().ajax()) {
-    mouseWentDown().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseDown(o, e);}}");
-    mouseWentUp().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseUp(o, e);}}");
-    mouseDragged().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseDrag(o, e);}}");
-    mouseMoved().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseMove(o, e);}}");
-    mouseWheel().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseWheel(o, e);}}");
-    mouseWentOut().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.mouseOut(o, e);}}");
-    touchStarted().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.touchStart(o, e);}}");
-    touchEnded().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.touchEnd(o, e);}}");
-    touchMoved().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.touchMoved(o, e);}}");
-    clicked().connect("function(o, e){var o=" + this->cObjJsRef() + ";if(o){o.clicked(o, e);}}");
-    jsSeriesSelected_.connect(this, &WCartesianChart::jsSeriesSelected);
-    loadTooltip_.connect(this, &WCartesianChart::loadTooltip);
-    voidEventSignal("dragstart", true)->preventDefaultAction(true);
+  hasAjax_ = WApplication::instance() && WApplication::instance()->environment().ajax();
+  if (hasAjax_) {
+    enableEventHandlers();
   }
 
   wheelActions_[KeyboardModifier::None] = InteractiveAction::PanMatching;

--- a/src/Wt/Chart/WCartesianChart.h
+++ b/src/Wt/Chart/WCartesianChart.h
@@ -1726,6 +1726,7 @@ private:
   bool onDemandLoadingEnabled_;
   WBrush loadingBackground_;
   bool cObjCreated_;
+  bool hasAjax_;
 
   Signal<const WDataSeries *, WPointF> seriesSelected_;
   JSignal<double, double> jsSeriesSelected_;
@@ -1764,6 +1765,8 @@ private:
   mutable std::vector<BarTooltip> barTooltips_;
 
   void init();
+  void enableEventHandlers();
+  virtual void enableAjax() override;
   static std::string wheelActionsToJson(WheelActions wheelActions);
 
   static WColor lightenColor(const WColor &in);


### PR DESCRIPTION
By registering the event handlers on the enableAjax call, the interactive components of WCarthesianChart also works when progressive bootstrap is enabled.

This has not been tested in depth, but seems to fix the issue we had with interactive plots not working as described in:
https://redmine.emweb.be/issues/7514

But maybe there is a better way to fix it?