### PR TITLE
Fix Android.C (putenv)

### DIFF
--- a/src/http/Android.C
+++ b/src/http/Android.C
@@ -3,6 +3,8 @@
 #include "WebController.h"
 #include "Wt/WServer.h"
 
+#include <boost/thread.hpp>
+
 #include "Android.h"
 
 #include <stdlib.h>
@@ -37,11 +39,14 @@ void preventRemoveOfSymbolsDuringLinking() {
           std::string env = s.substr(2);
           size_t index = env.find("=");
           if (index != std::string::npos) {
-            if (!putenv(env.c_str()))
-              std::cerr
-                << "WtAndroid::startwt putenv() failed on: "
-                << env
-                << std::endl;
+              std::string key = env.substr(0, index);
+              std::string value = env.substr(index + 1);
+              if (setenv(key.c_str(), value.c_str(), 1) != 0) {
+                std::cerr 
+                  << "WtAndroid::startwt setenv() failed on: " 
+                  << env 
+                  << std::endl;
+              }
           } else {
             std::cerr
               << "WtAndroid::startwt invalid environment variable definition: "


### PR DESCRIPTION
Fixes the following issues:

FAILED: src/http/CMakeFiles/wthttp.dir/Android.C.o
/Users/ben/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=aarch64-none-linux-android21 --sysroot=/Users/ben/Library/Android/sd$
/Users/ben/Development/thirdparty/vcpkg/buildtrees/wt/src/4.9.1-391a6b024e/src/http/Android.C:40:18: error: no matching function for call to 'putenv'
            if (!putenv(env.c_str()))
                 ^~~~~~
/Users/ben/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdlib.h:62:5: note: candidate function not viable: 1st argument ('co$
int putenv(char* __assignment);
    ^
/Users/ben/Development/thirdparty/vcpkg/buildtrees/wt/src/4.9.1-391a6b024e/src/http/Android.C:65:23: error: variable has incomplete type 'boost::thread'
        boost::thread mainThread(&main, argc, argv);
                      ^
/Users/ben/Development/thirdparty/vcpkg/installed/arm64-android/include/boost/thread/pthread/thread_data.hpp:88:11: note: forward declaration of 'boost::thread'
    class thread;
          ^
2 errors generated.