### PR TITLE
add #include <array> to fix compiler error

### DIFF
--- a/src/Wt/Dbo/backend/Postgres.C
+++ b/src/Wt/Dbo/backend/Postgres.C
@@ -20,6 +20,7 @@
 
 #include <libpq-fe.h>
 #include <algorithm>
+#include <array>
 #include <cerrno>
 #include <cstdio>
 #include <iostream>


### PR DESCRIPTION
I got a compiler error on my Debian 12 machine. Adding the missing #include fixes it:

```
[ 72%] Building CXX object src/Wt/Dbo/backend/CMakeFiles/wtdbopostgres.dir/Postgres.C.o
/home/deb/git/wt/src/Wt/Dbo/backend/Postgres.C: In function ‘std::string {anonymous}::double_to_s(double)’:
/home/deb/git/wt/src/Wt/Dbo/backend/Postgres.C:123:26: error: aggregate ‘std::array<char, 30> buf’ has incomplete type and cannot be defined
  123 |     std::array<char, 30> buf;
      |                          ^~~
/home/deb/git/wt/src/Wt/Dbo/backend/Postgres.C: In function ‘std::string {anonymous}::float_to_s(float)’:
/home/deb/git/wt/src/Wt/Dbo/backend/Postgres.C:148:26: error: aggregate ‘std::array<char, 30> buf’ has incomplete type and cannot be defined
  148 |     std::array<char, 30> buf;
      |                          ^~~
make[2]: *** [src/Wt/Dbo/backend/CMakeFiles/wtdbopostgres.dir/build.make:76: src/Wt/Dbo/backend/CMakeFiles/wtdbopostgres.dir/Postgres.C.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1854: src/Wt/Dbo/backend/CMakeFiles/wtdbopostgres.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```