### PR TITLE
Server.C: use separate variable for IPv6 resolver query

### DIFF
--- a/src/http/Server.C
+++ b/src/http/Server.C
@@ -331,8 +331,8 @@ std::vector<asio::ip::address> Server::resolveAddress(asio::ip::tcp::resolver &r
       LOG_DEBUG_S(&wt_, "Failed to resolve hostname \"" << address << "\" as IPv4: " <<
                   Wt::AsioWrapper::system_error(errc).what());
     // Resolve IPv6
-    query = Wt::AsioWrapper::asio::ip::tcp::resolver::query(Wt::AsioWrapper::asio::ip::tcp::v6(), address, "http");
-    for (Wt::AsioWrapper::asio::ip::tcp::resolver::iterator it = resolver.resolve(query, errc);
+    Wt::AsioWrapper::asio::ip::tcp::resolver::query query6(Wt::AsioWrapper::asio::ip::tcp::v6(), address, "http");
+    for (Wt::AsioWrapper::asio::ip::tcp::resolver::iterator it = resolver.resolve(query6, errc);
          !errc && it != end; ++it) {
       result.push_back(it->endpoint().address());
     }


### PR DESCRIPTION
Boost 1.85 no longer provides assignment operators for asio::ip::basic_resolver_query. This is because they recently added copy/move constructors, so the assignment operators are now implicitly deleted. I am not sure if this is intentional, as they do not follow the rule of five in this class. Either way Wt fails to build when attempting to reuse a query variable. The error can be avoided by creating a separate variable for the IPv6 query instead of reusing the one for IPv4 (the compiler will probably optimise the code anyway).