### PR TITLE
Fix doc/tutorial/auth.html 

### DIFF
--- a/doc/tutorial/auth.adoc
+++ b/doc/tutorial/auth.adoc
@@ -198,7 +198,7 @@ persistence/authentication `+Session+` object.
 [source,cpp]
 ----
 #include <Wt/Auth/Login.h>
-#include <Wt/Auth/UserDatabase.h>
+#include <Wt/Auth/Dbo/UserDatabase.h>
 
 #include <Wt/Dbo/Session.h>
 #include <Wt/Dbo/ptr.h>


### PR DESCRIPTION
Include statement in tutorial is incorrect:
`#include <Wt/Auth/UserDatabase.h>`

Fixed to:
`#include <Wt/Auth/Dbo/UserDatabase.h>`