### PR TITLE
WT-13355: Fix fuzz-eval target: add missing return statement

### DIFF
--- a/fuzz/fuzz-eval.C
+++ b/fuzz/fuzz-eval.C
@@ -24,6 +24,7 @@ namespace {
     } catch (Wt::WInvalidFormatException& ife) {
     } catch (Wt::WInvalidOperationException& ioe) {
     }
+    return 0;
   }
 }
 


### PR DESCRIPTION
The fuzz-eval target contains an issue - missing return statement in a non-void function. According to the C++ standard, it's an undefined behavior:

> Flowing off the end of a function is equivalent to a return with no value; this results in undefined behavior in a value-returning function.

In practice, it leads to fuzzer crash:

```
==268678== ERROR: libFuzzer: deadly signal
    #0 0x5589461e8ba1 in __sanitizer_print_stack_trace (fuzz-eval+0x763ba1)
    #1 0x558946141558 in fuzzer::PrintStackTrace() (fuzz-eval+0x6bc558)
    #2 0x558946127bf3 in fuzzer::Fuzzer::CrashCallback() (fuzz-eval+0x6a2bf3)
    #3 0x7fdd3a1af51f  (/lib/x86_64-linux-gnu/libc.so.6+0x4251f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #4 0x55894621dc78 in (anonymous namespace)::eval(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, unsigned long) wt/fuzz/fuzz-eval.C:25:5
    #5 0x55894621d5c8 in LLVMFuzzerTestOneInput wt/fuzz/fuzz-eval.C:38:5
    #6 0x5589461291b0 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (fuzz-eval+0x6a41b0)
    #7 0x558946128925 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) (fuzz-eval+0x6a3925)
    #8 0x55894612a586 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (fuzz-eval+0x6a5586)
    #9 0x55894612ab03 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (fuzz-eval+0x6a5b03)
    #10 0x558946118e7b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (fuzz-eval+0x693e7b)
    #11 0x558946141eb2 in main (fuzz-eval+0x6bceb2)
    #12 0x7fdd3a196d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #13 0x7fdd3a196e3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #14 0x55894610e2e4 in _start (fuzz-eval+0x6892e4)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 0 ; base unit: 0000000000000000000000000000000000000000
0xa,0x30,0x30,0x3f,0x30,0x26,0x38,0x30,0x26,0x30,
\01200?0&80&0
artifact_prefix='./'; Test unit written to ./crash-a72286086e84d763715310942975d7343b16dadb
Base64: CjAwPzAmODAmMA==
```

which makes the fuzz target useless - it cannot work efficiently.

Closes https://redmine.emweb.be/issues/13355