### PR TITLE
WSortFilterProxyModel inserted too few rows

### DIFF
--- a/src/Wt/WSortFilterProxyModel.C
+++ b/src/Wt/WSortFilterProxyModel.C
@@ -648,9 +648,14 @@ bool WSortFilterProxyModel::insertRows(int row, int count,
 
   Item *item = itemFromIndex(parent);
 
-  beginInsertRows(parent, row, row);
-  item->proxyRowMap_.push_back(sourceRow);
-  item->sourceRowMap_.insert(item->sourceRowMap_.begin() + sourceRow, row);
+  beginInsertRows(parent, row, row + count - 1);
+  for (int i = 0; i < count; i++) {
+    // item->proxyRowMap_.push_back(sourceRow + i);
+    item->proxyRowMap_.insert(item->proxyRowMap_.begin() + row + i,
+                              sourceRow + i);
+    item->sourceRowMap_.insert(item->sourceRowMap_.begin() + sourceRow + i,
+                               row + i);
+  }
   endInsertRows();
 
   return true;


### PR DESCRIPTION
If rows to a model are inserted via a WSortFilterProxyModel (i.e. a call to `WSortFilterProxyModel::insertRows()`), while the current implementation asks the underlying model to insert the correct number of rows, it then proceeds to assume that only exactly one row has been added in all cases.