### PR TITLE
fix: compatibility with boost-asio-1.87.0

### DIFF
--- a/src/Wt/AsioWrapper/asio.hpp
+++ b/src/Wt/AsioWrapper/asio.hpp
@@ -8,6 +8,7 @@
 #define WT_ASIO_ASIO_H_
 
 #include "Wt/WConfig.h"
+#include "io_service.hpp"
 
 #ifdef WT_ASIO_IS_BOOST_ASIO
 

--- a/src/Wt/AsioWrapper/io_service.hpp
+++ b/src/Wt/AsioWrapper/io_service.hpp
@@ -11,11 +11,29 @@
 
 #ifdef WT_ASIO_IS_BOOST_ASIO
 
+#include <boost/asio/version.hpp>
+#if BOOST_ASIO_VERSION >= 103300
+#include <boost/asio/io_context.hpp>
+namespace boost {
+  namespace asio {
+    using io_service = boost::asio::io_context;
+  }
+}
+#else
 #include <boost/asio/io_service.hpp>
+#endif
 
 #else // WT_ASIO_IS_STANDALONE_ASIO
 
+#include <asio/version.hpp>
+#if ASIO_VERSION >= 103300
+#include <asio/io_context.hpp>
+namespace asio {
+  using io_service = asio::io_context;
+}
+#else
 #include <asio/io_service.hpp>
+#endif
 
 #endif // WT_ASIO_IS_BOOST_ASIO
 

--- a/src/Wt/AsioWrapper/ssl.hpp
+++ b/src/Wt/AsioWrapper/ssl.hpp
@@ -12,10 +12,28 @@
 #ifdef WT_ASIO_IS_BOOST_ASIO
 
 #include <boost/asio/ssl.hpp>
+#if BOOST_ASIO_VERSION >= 103300
+namespace boost {
+  namespace asio {
+    namespace ssl {
+      using rfc2818_verification = boost::asio::ssl::host_name_verification;
+    }
+  }
+}
+#endif
 
 #else // WT_ASIO_IS_STANDALONE_ASIO
 
 #include <asio/ssl.hpp>
+#if ASIO_VERSION >= 103300
+namespace boost {
+  namespace asio {
+    namespace ssl {
+      using rfc2818_verification = boost::asio::ssl::host_name_verification;
+    }
+  }
+}
+#endif
 
 #endif // WT_ASIO_IS_BOOST_ASIO
 

--- a/src/Wt/AsioWrapper/steady_timer.hpp
+++ b/src/Wt/AsioWrapper/steady_timer.hpp
@@ -12,14 +12,6 @@
 #ifdef WT_ASIO_IS_BOOST_ASIO
 
 #include <boost/asio/steady_timer.hpp>
-#if BOOST_ASIO_VERSION >= 103300
-#include <boost/asio/io_context.hpp>
-namespace boost {
-  namespace asio {
-    using io_service = boost::asio::io_context;
-  }
-}
-#endif
 
 #else // WT_ASIO_IS_STANDALONE_ASIO
 

--- a/src/Wt/AsioWrapper/steady_timer.hpp
+++ b/src/Wt/AsioWrapper/steady_timer.hpp
@@ -12,6 +12,14 @@
 #ifdef WT_ASIO_IS_BOOST_ASIO
 
 #include <boost/asio/steady_timer.hpp>
+#if BOOST_ASIO_VERSION >= 103300
+#include <boost/asio/io_context.hpp>
+namespace boost {
+  namespace asio {
+    using io_service = boost::asio::io_context;
+  }
+}
+#endif
 
 #else // WT_ASIO_IS_STANDALONE_ASIO
 

--- a/src/Wt/Http/Client.h
+++ b/src/Wt/Http/Client.h
@@ -14,6 +14,7 @@
 #include <Wt/Http/Message.h>
 #include <Wt/Http/Method.h>
 
+#include <Wt/AsioWrapper/io_service.hpp>
 #include <Wt/AsioWrapper/namespace.hpp>
 #include <Wt/AsioWrapper/system_error.hpp>
 
@@ -21,42 +22,7 @@
 #include <string>
 #include <mutex>
 
-#ifndef WT_TARGET_JAVA
-#ifdef WT_ASIO_IS_BOOST_ASIO
-#include <boost/version.hpp>
-namespace boost {
-  namespace asio {
-#if BOOST_VERSION >= 106600
-    class io_context;
-    typedef io_context io_service;
-#else
-    class io_service;
-#endif
-  }
-}
-#else // WT_ASIO_IS_STANDALONE_ASIO
-#include <asio/version.hpp>
-namespace asio {
-#if ASIO_VERSION >= 101200
-  class io_context;
-  typedef io_context io_service;
-#else
-  class io_service;
-#endif
-}
-#endif // WT_ASIO_IS_BOOST_ASIO
-#endif // WT_TARGET_JAVA
-
 namespace Wt {
-
-#ifdef WT_TARGET_JAVA
-  namespace AsioWrapper {
-    namespace asio {
-      struct io_service;
-    }
-  }
-#endif // WT_TARGET_JAVA
-
   /*! \brief Namespace for \ref http handling
    */
   namespace Http {

--- a/src/Wt/Http/WtClient.C
+++ b/src/Wt/Http/WtClient.C
@@ -42,9 +42,9 @@ namespace {
     // Get a list of endpoints corresponding to the server name.
     tcp::resolver resolver(io_service);
 
-    tcp::resolver::query query(host, port);
-    tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-    tcp::resolver::iterator end;
+    auto resolver_result = resolver.resolve(host, port);
+    auto endpoint_iterator = resolver_result.begin();
+    auto end = resolver_result.end();
 
     // Try each endpoint until we successfully establish a connection.
     tcp::socket socket(io_service);

--- a/src/Wt/Mail/Client.C
+++ b/src/Wt/Mail/Client.C
@@ -107,12 +107,13 @@ public:
     tcp::resolver resolver(io_service_);
 
     AsioWrapper::error_code error = asio::error::host_not_found;
-    tcp::resolver::iterator endpoint_iterator = resolver.resolve(host, std::to_string(port), error);
+    auto resolver_result = resolver.resolve(host, std::to_string(port), error);
+    auto endpoint_iterator = resolver_result.begin();
+    auto end = resolver_result.end();
     if (error) {
       LOG_ERROR("could not resolve: '" << host << ":" << port << "': " << error.message());
       return;
     }
-    tcp::resolver::iterator end;
 
     // Try each endpoint until we successfully establish a connection.
     error = asio::error::host_not_found;

--- a/src/Wt/WWebSocketConnection.C
+++ b/src/Wt/WWebSocketConnection.C
@@ -925,7 +925,7 @@ void WWebSocketConnection::doSendPing(const AsioWrapper::error_code& e)
 bool WWebSocketConnection::sendPing()
 {
   if (pingTimeout_ > 0) {
-    pongTimeoutTimer_.expires_from_now(std::chrono::seconds(pingTimeout_));
+    pongTimeoutTimer_.expires_after(std::chrono::seconds(pingTimeout_));
     pongTimeoutTimer_.async_wait(std::bind(&WWebSocketConnection::missingPong, this, std::placeholders::_1));
   }
 
@@ -996,7 +996,7 @@ void WWebSocketConnection::startPingTimer()
 
   // Socket "keep-alive", performed through ping-pong mechanism.
   if (pingInterval_ > 0) {
-    pingSignalTimer_.expires_from_now(std::chrono::seconds(pingInterval_));
+    pingSignalTimer_.expires_after(std::chrono::seconds(pingInterval_));
     pingSignalTimer_.async_wait(std::bind(&WWebSocketConnection::doSendPing, this, std::placeholders::_1));
   }
 }

--- a/src/http/Reply.C
+++ b/src/http/Reply.C
@@ -471,8 +471,8 @@ void Reply::setConnection(ConnectionPtr connection)
 
 void Reply::receive()
 {
-  connection_->strand().post
-    (std::bind(&Connection::readMore, connection_,
+  asio::post
+    (connection_->strand(), std::bind(&Connection::readMore, connection_,
                shared_from_this(), 120));
 }
 
@@ -484,8 +484,8 @@ void Reply::send()
     LOG_DEBUG("Reply: send(): scheduling write response.");
 
     // We post this since we want to avoid growing the stack indefinitely
-    connection_->server()->service().post
-      (connection_->strand().wrap
+    asio::post
+      (connection_->server()->service(), connection_->strand().wrap
        (std::bind(&Connection::startWriteResponse, connection_,
                   shared_from_this())));
   }
@@ -570,8 +570,7 @@ bool Reply::encodeNextContentBuffer(
       originalSize += bs;
 
       gzipStrm_.avail_in = bs;
-      gzipStrm_.next_in = const_cast<unsigned char*>(
-            asio::buffer_cast<const unsigned char*>(b));
+      gzipStrm_.next_in = (unsigned char*)(b.data());
 
       unsigned char out[16*1024];
       do {

--- a/src/http/SessionProcess.C
+++ b/src/http/SessionProcess.C
@@ -46,7 +46,7 @@ SessionProcess::SessionProcess(SessionProcessManager *manager) noexcept
 
 void SessionProcess::requestStop() noexcept
 {
-  io_service_.post(strand_.wrap(
+  asio::post(io_service_, strand_.wrap(
           std::bind(&SessionProcess::stop, shared_from_this())));
 }
 

--- a/src/http/SessionProcessManager.C
+++ b/src/http/SessionProcessManager.C
@@ -50,7 +50,7 @@ SessionProcessManager::SessionProcessManager(asio::io_service &ioService,
     (std::bind(&SessionProcessManager::processDeadChildren, this,
                std::placeholders::_1));
 #else // !SIGNAL_SET
-  timer_.expires_from_now(std::chrono::seconds(CHECK_CHILDREN_INTERVAL));
+  timer_.expires_after(std::chrono::seconds(CHECK_CHILDREN_INTERVAL));
   timer_.async_wait
     (std::bind(&SessionProcessManager::processDeadChildren, this,
                std::placeholders::_1));
@@ -231,7 +231,7 @@ void SessionProcessManager::processDeadChildren(Wt::AsioWrapper::error_code ec)
     (std::bind(&SessionProcessManager::processDeadChildren, this,
                std::placeholders::_1));
 #else // !SIGNAL_SET
-  timer_.expires_from_now(std::chrono::seconds(CHECK_CHILDREN_INTERVAL));
+  timer_.expires_after(std::chrono::seconds(CHECK_CHILDREN_INTERVAL));
   timer_.async_wait
     (std::bind(&SessionProcessManager::processDeadChildren, this,
                std::placeholders::_1));

--- a/src/http/SslConnection.C
+++ b/src/http/SslConnection.C
@@ -98,7 +98,7 @@ void SslConnection::stop()
   std::shared_ptr<SslConnection> sft
     = std::static_pointer_cast<SslConnection>(shared_from_this());
 
-  sslShutdownTimer_.expires_from_now(std::chrono::seconds(1));
+  sslShutdownTimer_.expires_after(std::chrono::seconds(1));
   sslShutdownTimer_.async_wait
     (strand_.wrap(std::bind(&SslConnection::stopNextLayer,
                             sft, std::placeholders::_1)));
@@ -161,7 +161,7 @@ void SslConnection::handleReadRequestSsl(const Wt::AsioWrapper::error_code& e,
   // return in case of a recursive event loop, so the SSL write
   // deadlocks a session. Hence, post the processing of the data
   // read, so that the read handler can return here immediately.
-  strand_.post(std::bind(&SslConnection::handleReadRequest,
+  asio::post(strand_, std::bind(&SslConnection::handleReadRequest,
                          shared_from_this(),
                          e, bytes_transferred));
 }
@@ -197,7 +197,7 @@ void SslConnection::handleReadBodySsl(ReplyPtr reply,
   // See handleReadRequestSsl for explanation
   std::shared_ptr<SslConnection> sft
     = std::static_pointer_cast<SslConnection>(shared_from_this());
-  strand_.post(std::bind(&SslConnection::handleReadBody0,
+  asio::post(strand_, std::bind(&SslConnection::handleReadBody0,
                          sft, reply, e, bytes_transferred));
 }
 

--- a/src/web/Configuration.C
+++ b/src/web/Configuration.C
@@ -197,7 +197,7 @@ Configuration::Network Configuration::Network::fromString(const std::string &s)
   const auto slashPos = s.find('/');
   if (slashPos == std::string::npos) {
     AsioWrapper::error_code ec;
-    const auto address = AsioWrapper::asio::ip::address::from_string(s, ec);
+    const auto address = AsioWrapper::asio::ip::make_address(s, ec);
     if (ec) {
       throw std::invalid_argument("'" + s + "' is not a valid IP address");
     }
@@ -205,7 +205,7 @@ Configuration::Network Configuration::Network::fromString(const std::string &s)
     return Network { address, prefixLength };
   } else {
     AsioWrapper::error_code ec;
-    const auto address = AsioWrapper::asio::ip::address::from_string(s.substr(0, slashPos), ec);
+    const auto address = AsioWrapper::asio::ip::make_address(s.substr(0, slashPos), ec);
     if (ec) {
       throw std::invalid_argument("'" + s + "' is not a valid IP address");
     }
@@ -485,7 +485,7 @@ std::vector<Configuration::Network> Configuration::trustedProxies() const {
 bool Configuration::isTrustedProxy(const std::string &ipAddress) const {
   READ_LOCK;
   AsioWrapper::error_code ec;
-  const auto address = AsioWrapper::asio::ip::address::from_string(ipAddress, ec);
+  const auto address = AsioWrapper::asio::ip::make_address(ipAddress, ec);
   if (ec) {
     return false;
   }

--- a/src/web/WebMain.C
+++ b/src/web/WebMain.C
@@ -66,9 +66,9 @@ void WebMain::run()
       // simultaneously. Additionally, this breaks recursive event loops.
       // Asio's io_service::post does no such thing, so calling the function
       // of the superclass if fine.
-      static_cast<Wt::AsioWrapper::asio::io_service&>(server_->ioService())
-        .post(std::bind(&WebController::handleRequest,
-              &controller(), request));
+      AsioWrapper::asio::post(
+        static_cast<Wt::AsioWrapper::asio::io_service&>(server_->ioService()),
+        std::bind(&WebController::handleRequest, &controller(), request));
     }
   }
 


### PR DESCRIPTION
hi, asio removed some previously deprecated facilities, see https://www.boost.org/doc/libs/1_87_0/doc/html/boost_asio/history.html, I found this when I update vcpkg's boost to 1.87

base on https://github.com/emweb/wt/blob/master/doc/MinimumDependencyVersions.md, we need support boost>=1.66

so I made these changes, and all these functions can be found with boost-1.66:
* add io_service to `src\Wt\AsioWrapper\io_service.hpp`
* add rfc2818_verification to `src\Wt\AsioWrapper\ssl.hpp`
* remove tcp::resolver::query, use [ip::basic_resolver::resolve](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/ip__basic_resolver/resolve.html)
* use [tcp::resolver::results_type::iterator](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/ip__basic_resolver_results/iterator.html)
* use [asio::post](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/post.html)
* use [asio::executor_work_guard<asio::io_service::executor_type>](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/executor_work_guard.html)
* use [asio::io_context::restart](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/io_context/restart.html)
* use [asio::steady_timer::expires_after](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/basic_waitable_timer/expires_after.html)
* use [asio::ip::make_address](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/ip__address/make_address.html)
* remove buffer_cast, use [data()](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/buffer_cast.html)