### PR TITLE
Fix direction of WBoxLayout when implementing as flex

### DIFF
--- a/src/Wt/FlexLayoutImpl.C
+++ b/src/Wt/FlexLayoutImpl.C
@@ -386,9 +386,15 @@ std::string FlexLayoutImpl::styleFlex() const
 {
   switch (getDirection()) {
   case LayoutDirection::LeftToRight:
-    return "row";
+    if (LayoutDirection::LeftToRight == WApplication::instance()->layoutDirection())
+      return "row";
+    else
+      return "row-reverse";
   case LayoutDirection::RightToLeft:
-    return "row-reverse";
+    if (LayoutDirection::RightToLeft == WApplication::instance()->layoutDirection())
+      return "row";
+    else
+      return "row-reverse";
   case LayoutDirection::TopToBottom:
     return "column";
   case LayoutDirection::BottomToTop:


### PR DESCRIPTION
As explained [here](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/CSS_layout/Flexbox#columns_or_rows), flex-direction:row causes flex items to be laid out in the browser's default language direction (or body tag direction), but the FlexLayoutImpl::styleFlex() function always returns row for LayoutDirection::LeftToRight, whereas if the document direction is RTL, it should return row-reverse, and vice versa. To fix this problem, you should also consider the page orientation when specifying the flex-direction value.