### PR TITLE
Fix: The value assigned to the float property is the opposite

### DIFF
--- a/src/Wt/WWebWidget.C
+++ b/src/Wt/WWebWidget.C
@@ -1544,13 +1544,12 @@ void WWebWidget::updateDom(DomElement& element, bool all)
         */
         if (!app) app = WApplication::instance();
 
-        bool ltr = app->layoutDirection() == LayoutDirection::LeftToRight;
         switch (layoutImpl_->floatSide_) {
         case Side::Left:
-          element.setProperty(Property::StyleFloat, ltr ? "left" : "right");
+          element.setProperty(Property::StyleFloat,  "left");
           break;
         case Side::Right:
-          element.setProperty(Property::StyleFloat, ltr ? "right" : "left");
+          element.setProperty(Property::StyleFloat, "right");
           break;
         default:
           /* illegal values */


### PR DESCRIPTION
To specify the float value, the page orientation is taken into account, so if the page orientation is set to RTL, the value assigned to the float property will be the opposite, while as explained [Here](https://developer.mozilla.org/en-US/docs/Web/CSS/float), float:left and float:right operate independently of the page orientation.