### PR TITLE
Fix: The value assigned to the text-align property is the opposite

### DIFF
--- a/src/Wt/WContainerWidget.C
+++ b/src/Wt/WContainerWidget.C
@@ -351,16 +351,13 @@ void WContainerWidget::updateDom(DomElement& element, bool all)
   if (flags_.test(BIT_CONTENT_ALIGNMENT_CHANGED) || all) {
     AlignmentFlag hAlign = contentAlignment_ & AlignHorizontalMask;
 
-    bool ltr = WApplication::instance()->layoutDirection()
-      == LayoutDirection::LeftToRight;
-
     switch (hAlign) {
     case AlignmentFlag::Left:
       if (flags_.test(BIT_CONTENT_ALIGNMENT_CHANGED))
-        element.setProperty(Property::StyleTextAlign, ltr ? "left" : "right");
+        element.setProperty(Property::StyleTextAlign, "left");
       break;
     case AlignmentFlag::Right:
-      element.setProperty(Property::StyleTextAlign, ltr ? "right" : "left");
+      element.setProperty(Property::StyleTextAlign, "right");
       break;
     case AlignmentFlag::Center:
       element.setProperty(Property::StyleTextAlign, "center");


### PR DESCRIPTION
To specify the text-align value, the page orientation is taken into account, so if the page orientation is set to RTL, the value assigned to the text-align property will be the opposite, while text-align option operate independently of the page orientation.