### PR TITLE
WServerGLWidget.C: fix Apple GL for < 10.7

### DIFF
--- a/src/Wt/WServerGLWidget.C
+++ b/src/Wt/WServerGLWidget.C
@@ -47,7 +47,6 @@ typedef GLXContext (*glXCreateContextAttribsARBProc)(Display*, GLXFBConfig, GLXC
 #include <OpenGL/CGLCurrent.h>
 #include <OpenGL/CGLRenderers.h>
 #include <OpenGL/CGLTypes.h>
-#include <OpenGL/OpenGL.h>
 #include <AvailabilityMacros.h>
 #endif
 

--- a/src/Wt/WServerGLWidget.C
+++ b/src/Wt/WServerGLWidget.C
@@ -48,6 +48,7 @@ typedef GLXContext (*glXCreateContextAttribsARBProc)(Display*, GLXFBConfig, GLXC
 #include <OpenGL/CGLRenderers.h>
 #include <OpenGL/CGLTypes.h>
 #include <OpenGL/OpenGL.h>
+#include <AvailabilityMacros.h>
 #endif
 
 namespace {
@@ -254,9 +255,11 @@ WServerGLWidgetImpl::WServerGLWidgetImpl(bool antialiasingEnabled):
 {
   CGLPixelFormatAttribute attributes[4] = {
     kCGLPFAAccelerated,   // no software rendering
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
     kCGLPFAOpenGLProfile, // core profile with the version stated below
     (CGLPixelFormatAttribute) kCGLOGLPVersion_Legacy,
     //    (CGLPixelFormatAttribute) kCGLOGLPVersion_3_2_Core,
+#endif
     (CGLPixelFormatAttribute) 0
   };
   CGLPixelFormatObj pix;


### PR DESCRIPTION
Fixes the following error on 10.6:
```
/opt/local/var/macports/build/wt-4cd339fd/work/wt-4.12.0/src/Wt/WServerGLWidget.C: In constructor 'Wt::WServerGLWidgetImpl::WServerGLWidgetImpl(bool)':
/opt/local/var/macports/build/wt-4cd339fd/work/wt-4.12.0/src/Wt/WServerGLWidget.C:257:5: error: 'kCGLPFAOpenGLProfile' was not declared in this scope
  257 |     kCGLPFAOpenGLProfile, // core profile with the version stated below
      |     ^~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/wt-4cd339fd/work/wt-4.12.0/src/Wt/WServerGLWidget.C:258:31: error: 'kCGLOGLPVersion_Legacy' was not declared in this scope
  258 |     (CGLPixelFormatAttribute) kCGLOGLPVersion_Legacy,
      |                               ^~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [src/CMakeFiles/wt.dir/Wt/WServerGLWidget.C.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```