### PR TITLE
Add missing dropEvent overload

### DIFF
--- a/src/Wt/WAbstractProxyModel.C
+++ b/src/Wt/WAbstractProxyModel.C
@@ -82,6 +82,11 @@ void WAbstractProxyModel::dropEvent(const WDropEvent& e, DropAction action,
   sourceModel_->dropEvent(e, action, sourceRow, sourceColumn, sourceParent);
 }
 
+void WAbstractProxyModel::dropEvent(const WDropEvent &e, DropAction action,
+                                    const WModelIndex &index, Wt::Side side) {
+  sourceModel_->dropEvent(e, action, mapToSource(index), side);
+}
+
 void *WAbstractProxyModel::toRawIndex(const WModelIndex& index) const
 {
   return sourceModel_->toRawIndex(mapToSource(index));

--- a/src/Wt/WAbstractProxyModel.h
+++ b/src/Wt/WAbstractProxyModel.h
@@ -181,6 +181,14 @@ public:
                          int row, int column, const WModelIndex& parent)
     override;
 
+  /*! \brief Handles a drop event.
+   *
+   * The default proxy implementation maps the given index to the source model
+   * , and forwards the dropEvent call to the source model.
+   */
+  virtual void dropEvent(const WDropEvent &e, DropAction action,
+                         const WModelIndex &index, Wt::Side side) override;
+
   /*! \brief Converts a model index to a raw pointer that remains valid
    *         while the model's layout is changed.
    *


### PR DESCRIPTION
Dragging and dropping of items in between others (e.g. to move items inside a model) would have called the `WAbstractItemModel` implementation instead of correctly forwarding the call to the source model.