### PR TITLE
WT-14441: Avoid segfault on WApplication::setAsFocus during destruction

### DIFF
--- a/src/Wt/WApplication.C
+++ b/src/Wt/WApplication.C
@@ -391,6 +391,8 @@ std::string WApplication::onePixelGifUrl()
 
 WApplication::~WApplication()
 {
+  quitted_ = true;
+
 #ifndef WT_TARGET_JAVA
   Configuration& conf = env().server()->configuration();
   if (conf.servePrivateResourcesToBots() && env().agentIsSpiderBot()) {
@@ -1147,6 +1149,8 @@ EventSignal<>& WApplication::globalEscapePressed()
 
 void WApplication::setAsFocus(const std::string& id)
 {
+  if (!root() || hasQuit())
+    return;
   WWidget* w = root()->findById(id);
   if (w) {
     w->setFocus();


### PR DESCRIPTION
* generally set `quitted_` first in `~WApplication`
* `WApplication::setAsFocus`: 
  * check _all_ used pointers before use
  * bail out if the application has quit

Resolves https://redmine.emweb.be/issues/14441