### PR TITLE
WT-14474: Align overloads of WDialog::positionAt and suppress centerDialog

### DIFF
--- a/src/Wt/WDialog.C
+++ b/src/Wt/WDialog.C
@@ -643,9 +643,9 @@ void WDialog::setHidden(bool hidden, const WAnimation& animation)
 
     DialogCover *c = cover();
     if (!hidden) {
-      if (!WWebWidget::canOptimizeUpdates() || isRendered()) {
+      if ((!WWebWidget::canOptimizeUpdates() || isRendered()) && offset(Side::Left).isAuto()) {
         doJavaScript("var o = " + jsRef() + ";"
-                   "if (o && o.wtObj) o.wtObj.centerDialog();");
+                     "if (o && o.wtObj) o.wtObj.centerDialog();");
       }
       if (c)
         c->pushDialog(this, animation);
@@ -688,6 +688,8 @@ void WDialog::positionAt(const Wt::WMouseEvent& ev)
         setOffsets(ev.window().x, Side::Left);
         setOffsets(ev.window().y, Side::Top);
   }
+  if (isHidden())
+    show();
 }
 
 DialogCover *WDialog::cover()

--- a/src/Wt/WDialog.h
+++ b/src/Wt/WDialog.h
@@ -362,7 +362,7 @@ public:
                           WFlags<Orientation> adjustOrientations = AllOrientations)
     override;
 
-  /*! \brief Set the position of the widget at the mouse position
+  /*! \brief Sets the position of the widget at the mouse position and shows it if hidden.
    */
   void positionAt(const Wt::WMouseEvent& ev);
 


### PR DESCRIPTION
* `WDialog::positionAt(const WMouseEvent&)`: Show the dialog if hidden in order to
  - bring the position into effect
  - align the behavior with `WDialog::positionAt(const WWidget *, ...)`
* `WDialog::setHidden`: Suppress `wtObj.centerDialog()` if it has an x-offset (`setOffsets(..., Side::Left)`)
  which is the case if shown by both `WDialog::positionAt` overloads
  in order to avoid flicker with `WDialog::positionAt(const WMouseEvent&)`