### PR TITLE
fix(WMenuItem): setContents() on the current item moves the selection to the previous item

### DIFF
--- a/src/Wt/WMenu.C
+++ b/src/Wt/WMenu.C
@@ -283,10 +283,13 @@ std::unique_ptr<WMenuItem> WMenu::removeItem(WMenuItem *item)
 
     item->setParentMenu(nullptr);
 
-    if (itemIndex <= current_ && current_ >= 0)
+    if (itemIndex == current_) {
+      setCurrent(-1);
+      select(-1, true);
+    } else if (itemIndex < current_ && current_ > 0) {
       --current_;
-
-    select(current_, true);
+      select(current_, true);
+    }
   }
 
   return result;

--- a/src/Wt/WMenu.C
+++ b/src/Wt/WMenu.C
@@ -283,13 +283,10 @@ std::unique_ptr<WMenuItem> WMenu::removeItem(WMenuItem *item)
 
     item->setParentMenu(nullptr);
 
-    if (itemIndex == current_) {
-      setCurrent(-1);
-      select(-1, true);
-    } else if (itemIndex < current_ && current_ > 0) {
+    if (itemIndex <= current_ && current_ >= 0)
       --current_;
-      select(current_, true);
-    }
+
+    select(current_, true);
   }
 
   return result;

--- a/src/Wt/WMenuItem.C
+++ b/src/Wt/WMenuItem.C
@@ -109,8 +109,10 @@ void WMenuItem::setContents(std::unique_ptr<WWidget> contents,
   int menuIdx = -1;
   WMenu *menu = menu_;
   std::unique_ptr<WMenuItem> self;
+  bool wasCurrent = false;
   if (menu) {
     menuIdx = menu->indexOf(this);
+    wasCurrent = menu->currentItem() == this;
     self = menu->removeItem(this);
   }
 
@@ -133,6 +135,11 @@ void WMenuItem::setContents(std::unique_ptr<WWidget> contents,
 
   if (menu) {
     menu->insertItem(menuIdx, std::move(self));
+    if (wasCurrent) {
+      // Restore the selection without re-emitting triggered() / itemSelected()
+      menu->setCurrent(menuIdx);
+      menu->select(menuIdx, true);
+    }
   }
 }
 

--- a/test/widgets/WMenuTest.C
+++ b/test/widgets/WMenuTest.C
@@ -39,3 +39,56 @@ BOOST_AUTO_TEST_CASE(WMenu_addItem_change_index_for_internal_path_match)
   BOOST_TEST(menu->currentIndex() == previousIndex);
 }
 
+// Regression test: removeItem() must clear selection (not select the previous
+// item) when the currently-selected item is the one being removed.
+BOOST_AUTO_TEST_CASE(WMenu_removeItem_clears_selection_of_current_item)
+{
+  Wt::Test::WTestEnvironment testEnv;
+  Wt::WApplication app(testEnv);
+
+  Wt::WStackedWidget *stack = app.root()->addNew<Wt::WStackedWidget>();
+  Wt::WMenu *menu = app.root()->addNew<Wt::WMenu>(stack);
+
+  Wt::WMenuItem *item0 = menu->addItem("Item 0", std::make_unique<Wt::WText>("Content 0"));
+  Wt::WMenuItem *item1 = menu->addItem("Item 1", std::make_unique<Wt::WText>("Content 1"));
+  Wt::WMenuItem *item2 = menu->addItem("Item 2", std::make_unique<Wt::WText>("Content 2"));
+
+  // Select the middle item
+  menu->select(item1);
+  BOOST_REQUIRE(menu->currentIndex() == 1);
+
+  // Remove the currently-selected item — selection must be cleared, not moved
+  auto removed = menu->removeItem(item1);
+  BOOST_TEST(menu->currentIndex() == -1);
+  BOOST_TEST(menu->currentItem() == nullptr);
+
+  // Remaining items must be accessible at correct indices
+  BOOST_TEST(menu->count() == 2);
+  BOOST_TEST(menu->itemAt(0) == item0);
+  BOOST_TEST(menu->itemAt(1) == item2);
+}
+
+// Regression test: removeItem() must decrement current_ (not clear) when
+// an item *before* the currently-selected item is removed.
+BOOST_AUTO_TEST_CASE(WMenu_removeItem_before_current_keeps_selection)
+{
+  Wt::Test::WTestEnvironment testEnv;
+  Wt::WApplication app(testEnv);
+
+  Wt::WStackedWidget *stack = app.root()->addNew<Wt::WStackedWidget>();
+  Wt::WMenu *menu = app.root()->addNew<Wt::WMenu>(stack);
+
+  Wt::WMenuItem *item0 = menu->addItem("Item 0", std::make_unique<Wt::WText>("Content 0"));
+  Wt::WMenuItem *item1 = menu->addItem("Item 1", std::make_unique<Wt::WText>("Content 1"));
+  Wt::WMenuItem *item2 = menu->addItem("Item 2", std::make_unique<Wt::WText>("Content 2"));
+
+  // Select item2 (index 2)
+  menu->select(item2);
+  BOOST_REQUIRE(menu->currentIndex() == 2);
+
+  // Remove item0 (before current) — item2 must remain selected at new index 1
+  auto removed = menu->removeItem(item0);
+  BOOST_TEST(menu->currentItem() == item2);
+  BOOST_TEST(menu->currentIndex() == 1);
+}
+

--- a/test/widgets/WMenuTest.C
+++ b/test/widgets/WMenuTest.C
@@ -39,9 +39,9 @@ BOOST_AUTO_TEST_CASE(WMenu_addItem_change_index_for_internal_path_match)
   BOOST_TEST(menu->currentIndex() == previousIndex);
 }
 
-// Regression test: removeItem() must clear selection (not select the previous
-// item) when the currently-selected item is the one being removed.
-BOOST_AUTO_TEST_CASE(WMenu_removeItem_clears_selection_of_current_item)
+// Regression test: setContents() on the currently-selected item must not
+// change the active selection.
+BOOST_AUTO_TEST_CASE(WMenuItem_setContents_keeps_current_selection)
 {
   Wt::Test::WTestEnvironment testEnv;
   Wt::WApplication app(testEnv);
@@ -49,46 +49,16 @@ BOOST_AUTO_TEST_CASE(WMenu_removeItem_clears_selection_of_current_item)
   Wt::WStackedWidget *stack = app.root()->addNew<Wt::WStackedWidget>();
   Wt::WMenu *menu = app.root()->addNew<Wt::WMenu>(stack);
 
-  Wt::WMenuItem *item0 = menu->addItem("Item 0", std::make_unique<Wt::WText>("Content 0"));
+  menu->addItem("Item 0", std::make_unique<Wt::WText>("Content 0"));
   Wt::WMenuItem *item1 = menu->addItem("Item 1", std::make_unique<Wt::WText>("Content 1"));
-  Wt::WMenuItem *item2 = menu->addItem("Item 2", std::make_unique<Wt::WText>("Content 2"));
+  menu->addItem("Item 2", std::make_unique<Wt::WText>("Content 2"));
 
-  // Select the middle item
   menu->select(item1);
   BOOST_REQUIRE(menu->currentIndex() == 1);
 
-  // Remove the currently-selected item — selection must be cleared, not moved
-  auto removed = menu->removeItem(item1);
-  BOOST_TEST(menu->currentIndex() == -1);
-  BOOST_TEST(menu->currentItem() == nullptr);
+  item1->setContents(std::make_unique<Wt::WText>("New content 1"));
 
-  // Remaining items must be accessible at correct indices
-  BOOST_TEST(menu->count() == 2);
-  BOOST_TEST(menu->itemAt(0) == item0);
-  BOOST_TEST(menu->itemAt(1) == item2);
-}
-
-// Regression test: removeItem() must decrement current_ (not clear) when
-// an item *before* the currently-selected item is removed.
-BOOST_AUTO_TEST_CASE(WMenu_removeItem_before_current_keeps_selection)
-{
-  Wt::Test::WTestEnvironment testEnv;
-  Wt::WApplication app(testEnv);
-
-  Wt::WStackedWidget *stack = app.root()->addNew<Wt::WStackedWidget>();
-  Wt::WMenu *menu = app.root()->addNew<Wt::WMenu>(stack);
-
-  Wt::WMenuItem *item0 = menu->addItem("Item 0", std::make_unique<Wt::WText>("Content 0"));
-  Wt::WMenuItem *item1 = menu->addItem("Item 1", std::make_unique<Wt::WText>("Content 1"));
-  Wt::WMenuItem *item2 = menu->addItem("Item 2", std::make_unique<Wt::WText>("Content 2"));
-
-  // Select item2 (index 2)
-  menu->select(item2);
-  BOOST_REQUIRE(menu->currentIndex() == 2);
-
-  // Remove item0 (before current) — item2 must remain selected at new index 1
-  auto removed = menu->removeItem(item0);
-  BOOST_TEST(menu->currentItem() == item2);
+  BOOST_TEST(menu->currentItem() == item1);
   BOOST_TEST(menu->currentIndex() == 1);
 }
 


### PR DESCRIPTION
While testing `WMenuItem::setContents()`, I noticed that updating the contents of the currently selected menu item moves the selection to the previous item.

`setContents()` reinserts the item via `removeItem()`/`insertItem()`. `removeItem()` moves the selection to the previous item, which is the intended behavior for removals, but the reinsert doesn't restore the selection, so a pure contents update ends up changing the current item.

This change leaves `removeItem()` untouched. `setContents()` now remembers whether the item was current and restores the selection after reinserting it. The restore updates `current_` before calling `select()` (the same pattern `removeItem()` uses internally), so no spurious `triggered()`/`itemSelected()` signals are emitted.

Includes a regression test.